### PR TITLE
Add bounding box computed property to GridCell and tests

### DIFF
--- a/Engine/Grid/Grid.cs
+++ b/Engine/Grid/Grid.cs
@@ -29,6 +29,31 @@ public class SpawnGrid(List<List<GridCell>> spawnableCells, Position min, double
 
         return Cells[row][col];
     }
+
+    /// <summary>
+    /// Given a cell, compute the bounding box (min and max lat/lon) of that cell based on its center point and the grid's lat/lon size.
+    /// </summary>
+    /// <param name="cell"></param>
+    /// <returns>
+    /// A tuple containing the minimum and maximum Position (lat/lon) that defines the bounding box of the cell.
+    /// </returns>
+    public (Position Min, Position Max) GetBoundingBox(GridCell cell)
+    {
+        var halfLat = LatSize / 2.0;
+        var halfLon = LonSize / 2.0;
+
+        var min = new Position(
+            cell.Centerpoint.Longitude - halfLon,
+            cell.Centerpoint.Latitude - halfLat
+        );
+
+        var max = new Position(
+            cell.Centerpoint.Longitude + halfLon,
+            cell.Centerpoint.Latitude + halfLat
+        );
+
+        return (min, max);
+    }
 }
 
 /// <summary>
@@ -36,7 +61,7 @@ public class SpawnGrid(List<List<GridCell>> spawnableCells, Position min, double
 /// </summary>
 /// <param name="spawnable">Bool for spawnable or now.</param>
 /// <param name="centerpoint">Center of the grid.</param>
-public class GridCell(bool spawnable, Position centerpoint, double latSize, double lonSize)
+public class GridCell(bool spawnable, Position centerpoint)
 {
     /// <summary>
     /// Spawnable indicates whether this cell is spawnable (true) or not (false).
@@ -47,28 +72,4 @@ public class GridCell(bool spawnable, Position centerpoint, double latSize, doub
     /// The midpoint of the cell, represented as a Position (latitude and longitude).
     /// </summary>
     public Position Centerpoint = centerpoint;
-
-    /// <summary>
-    /// Computes the geographic bounding box of the cell based on its centre point and dimensions.
-    /// </summary>
-    /// <returns>
-    /// A tuple containing the minimum and maximum positions of the cell,
-    /// where Min is the south-west corner and Max is the north-east corner.
-    /// </returns>
-    public double LatSize { get; } = latSize;
-    public double LonSize { get; } = lonSize;
-
-    public (Position Min, Position Max) BoundingBox
-{
-    get
-    {
-        var halfLat = LatSize / 2.0;
-        var halfLon = LonSize / 2.0;
-
-        var min = new Position(Centerpoint.Longitude - halfLon, Centerpoint.Latitude - halfLat);
-        var max = new Position(Centerpoint.Longitude + halfLon, Centerpoint.Latitude + halfLat);
-
-        return (min, max);
-    }
-}
 }

--- a/Engine/Grid/Polygooner.cs
+++ b/Engine/Grid/Polygooner.cs
@@ -36,7 +36,7 @@ public static class Polygooner
                 var centerLon = min.Longitude + ((j + 0.5) * lonSize);
                 var centerPos = new Position(centerLon, centerLat);
                 var spawnable = polygons.Any(polygon => PointInPolygon(polygon, centerLon, centerLat));
-                row.Add(new GridCell(spawnable, centerPos, size, lonSize));
+                row.Add(new GridCell(spawnable, centerPos));
             }
 
             gridCells.Add(row);

--- a/Tests/Engine.test/JourneyPipeline.Test.cs
+++ b/Tests/Engine.test/JourneyPipeline.Test.cs
@@ -9,21 +9,27 @@ public class JourneyPipelineTests
     private class StubRouter : IMatrixRouter
     {
         private readonly float[] _distances;
+
         public StubRouter(float[] distances) => _distances = distances;
+
         public (float[], float[]) QueryPointsToPoints(double[] origins, double[] destinations)
             => ([], _distances);
     }
 
     private static Position Pos() => new(0.0, 0.0);
+
     private static City MakeCity(string name, int pop) => new(name, Pos(), pop);
-    private static GridCell SpawnableCell() => new(spawnable: true, Pos(), latSize: 1.0, lonSize: 1.0);
-    private static GridCell NonSpawnableCell() => new(spawnable: false, Pos(), latSize: 1.0, lonSize: 1.0);
+
+    private static GridCell SpawnableCell() => new(spawnable: true, Pos());
+
+    private static GridCell NonSpawnableCell() => new(spawnable: false, Pos());
 
     private static SpawnGrid MakeGrid(int spawnableCount, int nonSpawnableCount = 0)
     {
         var row = Enumerable.Repeat(SpawnableCell(), spawnableCount)
             .Concat(Enumerable.Repeat(NonSpawnableCell(), nonSpawnableCount))
             .ToList();
+
         return new SpawnGrid([row], min: new Position(0.0, 0.0), latSize: 1.0, lonSize: 1.0);
     }
 
@@ -57,7 +63,7 @@ public class JourneyPipelineTests
         var grid = MakeGrid(spawnableCount: 1);
         var cities = new List<City>
         {
-            MakeCity("Reachable",   pop: 5000),
+            MakeCity("Reachable", pop: 5000),
             MakeCity("Unreachable", pop: 9999)
         };
 
@@ -72,11 +78,11 @@ public class JourneyPipelineTests
     {
         var grid = MakeGrid(spawnableCount: 1);
         var cities = new List<City>
-    {
-        MakeCity("Big",   pop: 1_000_000),
-        MakeCity("Small", pop: 1_000)
-    };
-        // equal distance so only population drives the weight difference
+        {
+            MakeCity("Big", pop: 1_000_000),
+            MakeCity("Small", pop: 1_000)
+        };
+
         var pipeline = new JourneyPipeline(grid, cities, new StubRouter([500f, 500f]));
         var rng = new Random(42);
 
@@ -85,13 +91,13 @@ public class JourneyPipelineTests
 
         var lowCounts = new int[2];
         var highCounts = new int[2];
+
         for (var i = 0; i < 10_000; i++)
         {
             lowCounts[lowSamplers.DestinationSamplers[0].Sample(rng)]++;
             highCounts[highSamplers.DestinationSamplers[0].Sample(rng)]++;
         }
 
-        // index 0 = Big city. Higher scaler should make it even more dominant.
         var lowBigCityRatio = (double)lowCounts[0] / lowCounts[1];
         var highBigCityRatio = (double)highCounts[0] / highCounts[1];
 
@@ -101,20 +107,23 @@ public class JourneyPipelineTests
     }
 
     [Fact]
-    public void Compute_NoSpawnableCells_Throws()
+    public void Compute_NoSpawnableCells_ReturnsNull()
     {
         var grid = MakeGrid(spawnableCount: 0);
         var cities = new List<City> { MakeCity("X", pop: 5000) };
 
         var pipeline = new JourneyPipeline(grid, cities, new StubRouter([]));
+
         Assert.Null(pipeline.Compute(scaler: 1.0f));
     }
 
     [Fact]
     public void BoundingBox_ReturnsExpectedMinMax_NormalCell()
     {
-        var cell = new GridCell(spawnable: true, new Position(10.0, 20.0), latSize: 2.0, lonSize: 4.0);
-        var (min, max) = cell.BoundingBox;
+        var grid = new SpawnGrid([], new Position(0.0, 0.0), latSize: 2.0, lonSize: 4.0);
+        var cell = new GridCell(spawnable: true, new Position(10.0, 20.0));
+
+        var (min, max) = grid.GetBoundingBox(cell);
 
         Assert.Equal(8.0, min.Longitude);
         Assert.Equal(19.0, min.Latitude);
@@ -122,10 +131,13 @@ public class JourneyPipelineTests
         Assert.Equal(21.0, max.Latitude);
     }
 
+    [Fact]
     public void BoundingBox_ReturnsExpectedMinMax_UnitCell()
     {
-        var cell = new GridCell(spawnable: true, new Position(0.0, 0.0), latSize: 1.0, lonSize: 1.0);
-        var (min, max) = cell.BoundingBox;
+        var grid = new SpawnGrid([], new Position(0.0, 0.0), latSize: 1.0, lonSize: 1.0);
+        var cell = new GridCell(spawnable: true, new Position(0.0, 0.0));
+
+        var (min, max) = grid.GetBoundingBox(cell);
 
         Assert.Equal(-0.5, min.Longitude);
         Assert.Equal(-0.5, min.Latitude);
@@ -133,13 +145,15 @@ public class JourneyPipelineTests
         Assert.Equal(0.5, max.Latitude);
     }
 
+    [Fact]
     public void BoundingBox_ContainsCenterPoint()
     {
-        var cell = new GridCell(spawnable: true, new Position(5.0, 5.0), latSize: 2.0, lonSize: 2.0);
-        var (min, max) = cell.BoundingBox;
+        var grid = new SpawnGrid([], new Position(0.0, 0.0), latSize: 2.0, lonSize: 2.0);
+        var cell = new GridCell(spawnable: true, new Position(5.0, 5.0));
+
+        var (min, max) = grid.GetBoundingBox(cell);
 
         Assert.InRange(cell.Centerpoint.Longitude, min.Longitude, max.Longitude);
         Assert.InRange(cell.Centerpoint.Latitude, min.Latitude, max.Latitude);
     }
-
 }


### PR DESCRIPTION
## Issue Number
#43 

## Description of Implementation
This PR adds a computed `BoundingBox` property to `GridCell`.

Previously, a grid cell only stored its centre point. By also storing the cell size (`LatSize`, `LonSize`), each cell can now compute its geographic bounding box.

This makes it possible to determine the full spatial extent of a cell and will allow spawning vehicles at random positions inside the cell instead of always at the centre.

Additional changes:
- Added `LatSize` and `LonSize` to `GridCell`
- Updated grid generation to pass cell size when creating cells
- Added unit tests verifying bounding box correctness

---

## Pre-PR Checklist
- [x] All new and modified code has been thoroughly tested with relevant tests (Unit tests, integration test and performance test).
- [x] Functions have been documented with overall descriptions.
- [x] Function parameters have been described.
- [x] Function return values have been described.