### PR TITLE
Template auto close

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,15 @@
-Issue Number: #
+# Related Issues
+<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
+Closes #
 
-Description of Implementation (optional):
+## Description of Implementation (optional)
+<!-- Briefly explain what this PR does and why -->
+
+## Notes
+<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->
 
 ## Pre-PR Checklist
 Ensure these are completed before opening the PR:
 
-- [ ] All new and modified code has been tested. (Argue if not tested in desc)
+- [ ] All new and modified code has been tested (explain in Notes if not tested)  
+- [ ] Self-review completed  


### PR DESCRIPTION
Issue Number: None

Description of Implementation (optional):
Figured out that closes keyword automatically links issues in the development section and enables automatically moving issues to completed when merging 'https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [ ] All new and modified code has been tested. (Argue if not tested in desc)
Self explanatory
