### PR TITLE
Add cost weights and calculations

### DIFF
--- a/Benchmark/Engine.Benchmark/FindCandidateStationsBenchmark.cs
+++ b/Benchmark/Engine.Benchmark/FindCandidateStationsBenchmark.cs
@@ -68,7 +68,7 @@ public class FindCandidateStationsBenchmark
         var costWeigths = new CostWeights(PathDeviation: 1);
         var costStore = new CostStore(costWeigths);
         var stationService = new BenchmarkStationService(stations);
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
 
         _eventScheduler = new EventScheduler();
         _evStore = new EVStore(_count);

--- a/Core/Vehicles/EV.cs
+++ b/Core/Vehicles/EV.cs
@@ -124,5 +124,4 @@ public struct EV(Battery battery, Preferences preferences, Journey journey, usho
     /// <summary>Calculates the energy required to travel <paramref name="distanceKm"/>.</summary>
     private readonly float EnergyForDistanceKWh(float distanceKm) =>
         distanceKm * ConsumptionWhPerKm / 1000f;
-
 }

--- a/Core/Vehicles/Urgency.cs
+++ b/Core/Vehicles/Urgency.cs
@@ -31,9 +31,7 @@ public static class Urgency
         if (soc <= minSoc)
             return 1.0;
 
-        const double steepness = 2.0;
-        var normalizedPosition = (upperChargeLimit - soc) / (upperChargeLimit - minSoc);
-        return Math.Clamp(Math.Pow(normalizedPosition, steepness), 0.0, 1.0);
+        return 0.02 * Math.Pow(soc * 100, 2);
     }
 
     /// <summary>

--- a/Engine/Cost/ComputeCost.cs
+++ b/Engine/Cost/ComputeCost.cs
@@ -75,7 +75,7 @@ public class ComputeCost(ICostStore costStore, IStationService stationService)
 
         var totalQueueSize = stationService.GetTotalQueueSize(station.Id);
         var effectiveQueueSize = (float)totalQueueSize / station.Chargers.Count(s => s.GetSockets().Contains(socket));
-        return weights.EffectiveQueueSize * MathF.Pow(effectiveQueueSize, 2);
+        return weights.EffectiveQueueSize * MathF.Pow(effectiveQueueSize, 3);
     }
 
     /// <summary>
@@ -100,8 +100,9 @@ public class ComputeCost(ICostStore costStore, IStationService stationService)
 
     private static float CalculatePriceCost(ref EV ev, Station station, CostWeights weights, Time time)
     {
-        var price = station.GetPrice(time);
-        return weights.PriceSensitivity * ev.Preferences.PriceSensitivity * price;
+        var currentPrice = station.GetPrice(time);
+        var averagePrice = 3.525304f; // Average price across all stations and times, used for normalization
+        return weights.PriceSensitivity * ev.Preferences.PriceSensitivity * (currentPrice - averagePrice);
     }
 
     // TODO: Implement

--- a/Engine/Cost/ComputeCost.cs
+++ b/Engine/Cost/ComputeCost.cs
@@ -11,7 +11,8 @@ using Engine.Services;
 /// </summary>
 /// <param name="costStore">The cost store.</param>
 /// <param name="stationService">The station service.</param>
-public class ComputeCost(ICostStore costStore, IStationService stationService)
+/// <param name="energyPrices">The energy prices.</param>
+public class ComputeCost(ICostStore costStore, IStationService stationService, EnergyPrices energyPrices)
 {
     /// <summary>
     /// Computes the cost of detouring to each station and selects the station with the lowest cost.
@@ -35,7 +36,7 @@ public class ComputeCost(ICostStore costStore, IStationService stationService)
             var effectiveQueueCost = CalculateEffectiveQueueSizeCost(station, weights, ev.Battery.Socket);
             var pathDeviationCost = CalculatePathDeviationCost(ref ev, duration, weights, time);
             var urgencyCost = CalculateUrgencyCost(ref ev, weights);
-            var priceCost = CalculatePriceCost(ref ev, station, weights, time);
+            var priceCost = CalculatePriceCost(ref ev, station, weights, time, energyPrices);
             var effectiveWaitTimeCost = CalculateEffectiveWaitTimeCost(weights);
             var cost = effectiveQueueCost + pathDeviationCost + urgencyCost + priceCost + effectiveWaitTimeCost;
 
@@ -98,10 +99,10 @@ public class ComputeCost(ICostStore costStore, IStationService stationService)
         return weights.Urgency * urgency;
     }
 
-    private static float CalculatePriceCost(ref EV ev, Station station, CostWeights weights, Time time)
+    private static float CalculatePriceCost(ref EV ev, Station station, CostWeights weights, Time time, EnergyPrices energyPrices)
     {
         var currentPrice = station.GetPrice(time);
-        var averagePrice = 3.525304f; // Average price across all stations and times, used for normalization
+        var averagePrice = energyPrices.GetHourPrice(time.DayOfWeek, (int)time.Hour);
         return weights.PriceSensitivity * ev.Preferences.PriceSensitivity * (currentPrice - averagePrice);
     }
 

--- a/Engine/Cost/CostWeights.cs
+++ b/Engine/Cost/CostWeights.cs
@@ -1,12 +1,12 @@
 namespace Engine.Cost;
 
 public record CostWeights(
-    float PriceSensitivity = 0,
-    float PathDeviation = 0,
-    float EffectiveQueueSize = 0,
-    float Urgency = 0,
-    float ExpectedWaitTime = 0,
-    float AvailableChargerRatio = 0
+    float PriceSensitivity = 0.4f,
+    float PathDeviation = 0.8f,
+    float EffectiveQueueSize = 1.0f,
+    float Urgency = 0.5f,
+    float ExpectedWaitTime = 0, // unchanged, as it is not yet implemented.
+    float AvailableChargerRatio = 0 // unchanged, as it is not yet implemented.
 
 // ...
 );

--- a/Engine/Events/EventDispatcher.cs
+++ b/Engine/Events/EventDispatcher.cs
@@ -28,34 +28,6 @@ public class EventDispatcher(
         DestinationArrivalHandler destinationArrivalHandler,
         CheckAndUpdateAllEVsHandler CheckAndUpdateAllEVsHandler)
 {
-    private Dictionary<Type, uint> _calledCount = [];
-    private int _eventCount;
-
-    private void IncrementCount(Event e)
-    {
-        var type = e.GetType();
-
-        if (_calledCount.ContainsKey(type))
-        {
-            _calledCount[type]++;
-        }
-        else
-        {
-            _calledCount[type] = 1;
-        }
-
-        _eventCount++;
-    }
-
-    private void PrintCounts(Event e)
-    {
-        Console.WriteLine($"Event counts in timestamp {e.Time}:");
-        foreach (var kvp in _calledCount)
-        {
-            Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}");
-        }
-    }
-
     /// <summary>
     /// Dispatches the event to the correct handler.
     /// Has a handler for every <c>Event</c>. If an event is dispatched for which there is no handler, an exception is thrown.
@@ -114,5 +86,33 @@ public class EventDispatcher(
 
         if (_eventCount % 1000 == 0)
             PrintCounts(e);
+    }
+
+    private Dictionary<Type, uint> _calledCount = [];
+    private int _eventCount;
+
+    private void IncrementCount(Event e)
+    {
+        var type = e.GetType();
+
+        if (_calledCount.ContainsKey(type))
+        {
+            _calledCount[type]++;
+        }
+        else
+        {
+            _calledCount[type] = 1;
+        }
+
+        _eventCount++;
+    }
+
+    private void PrintCounts(Event e)
+    {
+        Console.WriteLine($"Event counts in timestamp {e.Time}:");
+        foreach (var kvp in _calledCount)
+        {
+            Console.WriteLine($"{kvp.Key.Name}: {kvp.Value}");
+        }
     }
 }

--- a/Engine/Init/Init.cs
+++ b/Engine/Init/Init.cs
@@ -205,7 +205,8 @@ public static class Init
         {
             var costStore = sp.GetRequiredService<ICostStore>();
             var stationService = sp.GetRequiredService<StationService>();
-            return new ComputeCost(costStore, stationService);
+            var energyPrices = sp.GetRequiredService<EnergyPrices>();
+            return new ComputeCost(costStore, stationService, energyPrices);
         });
 
         services.AddSingleton(sp =>

--- a/Tests/Engine.test/Cost/ComputeCostTest.cs
+++ b/Tests/Engine.test/Cost/ComputeCostTest.cs
@@ -15,12 +15,13 @@ public class ComputeCostTest
     public void Compute_OnlyPathDeviationWeighted_SelectsLowerDeviationStation()
     {
         var costStore = new TestData.StubCostStore(new CostWeights(PathDeviation: 1));
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 1, TestData.Station(id: 1, pos: new Position(0, 0)) },
             { 2, TestData.Station(id: 2, pos: new Position(0, 0)) },
         });
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
         var ev = new EV(
             TestData.Battery(stateOfCharge: 100),
             TestData.Preferences(PriceSensitivity: 0.0f, MinAcceptableCharge: 0f),
@@ -44,12 +45,13 @@ public class ComputeCostTest
     public void Compute_OnlyQueueWeighted_SelectsShorterQueueStation()
     {
         var costStore = new TestData.StubCostStore(new CostWeights(EffectiveQueueSize: 1));
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 1, TestData.Station(id: 1, pos: new Position(0, 0), queueSize: 1) },
             { 2, TestData.Station(id: 2, pos: new Position(0, 0), queueSize: 3) },
         });
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
         var ev = new EV(
             TestData.Battery(stateOfCharge: 100),
             TestData.Preferences(PriceSensitivity: 0.0f, MinAcceptableCharge: 0f),
@@ -69,7 +71,7 @@ public class ComputeCostTest
 
     [Theory]
     [InlineData(0.5f, 2)] // Low deviation weight -> Station 2 wins (much shorter queue)
-    [InlineData(2.0f, 1)] // High deviation weight -> Station 1 wins (no deviation)
+    [InlineData(7.0f, 1)] // High deviation weight -> Station 1 wins (no deviation)
     public void Compute_QueueVsPathDeviation_SelectsBasedOnWeights(float pathDeviationWeight, ushort expectedStationId)
     {
         var costStore = new TestData.StubCostStore(
@@ -77,13 +79,15 @@ public class ComputeCostTest
                 PathDeviation: pathDeviationWeight,
                 EffectiveQueueSize: 1.0f));
 
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
+
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 1, TestData.Station(id: 1, pos: new Position(0, 0), queueSize: 4) },
             { 2, TestData.Station(id: 2, pos: new Position(0, 0), queueSize: 1) },
         });
 
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
 
         var ev = new EV(
             TestData.Battery(stateOfCharge: 0.5f),
@@ -110,6 +114,7 @@ public class ComputeCostTest
     {
         var weights = new CostWeights(PathDeviation: 0.5f, EffectiveQueueSize: 1.0f, Urgency: 10.0f);
         var costStore = new TestData.StubCostStore(weights);
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
 
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
@@ -117,7 +122,7 @@ public class ComputeCostTest
             { 2, TestData.Station(id: 2, pos: new Position(0, 0), queueSize: 1) },
         });
 
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
 
         var ev = new EV(
             TestData.Battery(stateOfCharge: stateOfCharge),
@@ -139,12 +144,13 @@ public class ComputeCostTest
     public void Compute_AllStationsIdenticalCost_ReturnsFirst()
     {
         var costStore = new TestData.StubCostStore(new CostWeights(PathDeviation: 1, EffectiveQueueSize: 1));
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 1, TestData.Station(id: 1, pos: new Position(0, 0), queueSize: 0) },
             { 2, TestData.Station(id: 2, pos: new Position(0, 0), queueSize: 0) },
         });
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
         var ev = new EV(
             TestData.Battery(stateOfCharge: 100),
             TestData.Preferences(PriceSensitivity: 0.0f, MinAcceptableCharge: 0f),
@@ -169,12 +175,13 @@ public class ComputeCostTest
     public void Compute_OnlyPriceSensitivityWeighted_SelectsCheaperStation()
     {
         var costStore = new TestData.StubCostStore(new CostWeights(PriceSensitivity: 1));
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 1, TestData.Station(id: 1, pos: new Position(0, 0), energyPrices: new TestData.FixedEnergyPrices(2.0f)) },
             { 2, TestData.Station(id: 2, pos: new Position(1, 1), energyPrices: new TestData.FixedEnergyPrices(4.0f)) },
         });
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
         var ev = new EV(
             TestData.Battery(stateOfCharge: 50),
             TestData.Preferences(PriceSensitivity: 1.0f, MinAcceptableCharge: 20f),
@@ -200,7 +207,8 @@ public class ComputeCostTest
     {
         var costStore = new TestData.StubCostStore(new CostWeights(PathDeviation: 1));
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>());
-        var computeCost = new ComputeCost(costStore, stationService);
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
         var ev = new EV(
             TestData.Battery(stateOfCharge: 100),
             TestData.Preferences(PriceSensitivity: 0.0f, MinAcceptableCharge: 0f),
@@ -220,12 +228,13 @@ public class ComputeCostTest
     public void Compute_AfterBeingRerouted_StillCalculatesPathDeviationCorrectly()
     {
         var costStore = new TestData.StubCostStore(new CostWeights(PathDeviation: 1));
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 1, TestData.Station(id: 1, pos: new Position(0, 0)) },
             { 2, TestData.Station(id: 2, pos: new Position(0, 0)) },
         });
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
 
         var ev = TestData.EV(
             waypoints: [new Position(0, 0), new Position(1, 1)],
@@ -256,13 +265,14 @@ public class ComputeCostTest
         // Test simulates full chain: A -> Station A -> B, then detour again to a station
         // Validates that path deviation cost works through multiple reroutes
         var costStore = new TestData.StubCostStore(new CostWeights(PathDeviation: 1));
+        var energyPrices = new TestData.FixedEnergyPrices(2.0f);
         var stationService = new TestData.StubStationService(new Dictionary<ushort, Station>
         {
             { 10, TestData.Station(id: 10, pos: new Position(0.5f, 0.5f)) },
             { 20, TestData.Station(id: 20, pos: new Position(0, 0)) },
             { 30, TestData.Station(id: 30, pos: new Position(0, 0)) },
         });
-        var computeCost = new ComputeCost(costStore, stationService);
+        var computeCost = new ComputeCost(costStore, stationService, energyPrices);
 
         var ev = TestData.EV(
             waypoints: [new Position(0, 0), new Position(1, 1)],


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
Added weights to costs, and updated some parts of how our cost function finds the best station. Also fixed a warning in the dispatcher (public members must come before private members) and the EV.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->
There's a test in urgency handler that fails, which confuses me because I don't think I at all interacted with anything to do with the urgency handler, other than the urgency cost. The test fails because it expects no events, but sees a FindCandidateStations event.

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  