### PR TITLE
Reproduce

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -119,3 +119,4 @@ dotnet_diagnostic.SA1600.severity = none
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.CS1591.severity = none
 dotnet_diagnostic.SA1202.severity = none
+dotnet_diagnostic.SA1401.severity = none

--- a/Engine/Events/EventScheduler.cs
+++ b/Engine/Events/EventScheduler.cs
@@ -6,7 +6,7 @@ using Core.Shared;
 /// The EventScheduler is responsible for managing and scheduling events in the system.
 /// </summary>
 /// <param name="preProcessors">Middleware/Preprocessors that are fired on MiddlewareEvents if attatched.</param>
-public class EventScheduler(Dictionary<Type, Action<IMiddlewareEvent>>? preProcessors = null)
+public class EventScheduler(Dictionary<Type, Action<IMiddlewareEvent>>? preProcessors = null) : IEventScheduler
 {
     private readonly PriorityQueue<Event, (Time, uint)> _eventPriorityQueue = new();
 

--- a/Engine/Events/IEventScheduler.cs
+++ b/Engine/Events/IEventScheduler.cs
@@ -1,0 +1,10 @@
+namespace Engine.Events;
+
+using Core.Shared;
+
+public interface IEventScheduler
+{
+    Time CurrentTime { get; }
+    uint ScheduleEvent(Event e);
+}
+

--- a/Engine/Vehicles/EVFactory.cs
+++ b/Engine/Vehicles/EVFactory.cs
@@ -3,12 +3,13 @@ namespace Engine.Vehicles;
 using Core.Routing;
 using Core.Shared;
 using Core.Vehicles;
+using Core.Vehicles.Configs;
 using Engine.Routing;
 using Engine.Spawning;
 using Engine.Utils;
 
 /// <summary>
-/// Factory for creating EVs, supporting for single or batch creation.
+/// Factory for creating EVs, supporting single or batch creation.
 /// </summary>
 /// <param name="random">An instance of Random.</param>
 /// <param name="samplersProvider">The provider of the samplers used to sample the EVs' journeys.</param>
@@ -18,47 +19,83 @@ public class EVFactory(Random random, IJourneySamplerProvider samplersProvider, 
     private readonly AliasSampler _sampler = new([.. EVModels.Models.Select(m => m.SpawnChance)]);
 
     /// <summary>
-    /// Used to create a single EV.
+    /// Creates a single EV. For batch creation use <see cref="SampleParams"/> and <see cref="Create(SampledEVParams, Time)"/>.
     /// </summary>
-    /// <param name="departure">The depature of the created EV's journey.</param>
+    /// <param name="departure">The departure time of the created EV's journey.</param>
     /// <returns>An EV conforming to the supplied configs.</returns>
     public EV Create(Time departure)
     {
-        var config = EVModels.Models[_sampler.Sample(random)];
-        var batteryConfig = config.BatteryConfig;
-        var maxCapacity = batteryConfig.MaxCapacityKWh;
-        var chargeRate = batteryConfig.ChargeRateKW;
-        var currCharge = NextFloatInRange(0.4f, 1f);
-        var battery = new Battery(maxCapacity, chargeRate, currCharge, batteryConfig.Socket);
-
-        var priceSensPref = random.NextSingle();
-        var minAcceptableCharge = NextFloatInRange(0.05f, 0.4f);
-        var maxPathDeviation = NextFloatInRange(5.0f, 30.0f);
-        var preferences = new Preferences(priceSensPref, minAcceptableCharge, maxPathDeviation);
-
-        var journey = CreateJourney(departure);
-        return new EV(battery, preferences, journey, config.Efficiency);
-    }
-
-    private Journey CreateJourney(Time departure)
-    {
-        var (source, destination) = samplersProvider.Current.SampleSourceToDest(random);
-        var queryResult = pointToPointRouter.QuerySingleDestination(
-                        source.Longitude,
-                        source.Latitude,
-                        destination.Longitude,
-                        destination.Latitude);
-
-        var path = Polyline6ToPoints.DecodePolyline(queryResult.Polyline);
-        return new Journey(
-                departure,
-                (Time)(uint)queryResult.Duration,
-                queryResult.Distance,
-                path);
+        var p = SampleParams(1)[0];
+        return Create(p, departure);
     }
 
     /// <summary>
-    /// Scale the value to be between min and max.
+    /// Contains all randomly sampled values needed to create an EV, allowing
+    /// <see cref="Create(SampledEVParams, Time)"/> to be called without any further random sampling.
+    /// </summary>
+    public record SampledEVParams(
+        EVConfig Config,
+        float CurrCharge,
+        float PriceSensPref,
+        float MinAcceptableCharge,
+        float MaxPathDeviation,
+        (Position Source, Position Destination) SourceDest
+    );
+
+    /// <summary>
+    /// Creates a single EV from pre-sampled parameters. This method is thread-safe
+    /// and can be called in parallel as it performs no random sampling.
+    /// </summary>
+    /// <param name="p">The pre-sampled parameters produced by <see cref="SampleParams"/>.</param>
+    /// <param name="departure">The departure time of the created EV's journey.</param>
+    /// <returns>An EV conforming to the sampled parameters.</returns>
+    public EV Create(SampledEVParams p, Time departure)
+    {
+        var batteryConfig = p.Config.BatteryConfig;
+        var battery = new Battery(batteryConfig.MaxCapacityKWh, batteryConfig.ChargeRateKW, p.CurrCharge, batteryConfig.Socket);
+        var preferences = new Preferences(p.PriceSensPref, p.MinAcceptableCharge, p.MaxPathDeviation);
+        var journey = CreateJourney(departure, p.SourceDest);
+        return new EV(battery, preferences, journey, p.Config.Efficiency);
+    }
+
+    /// <summary>
+    /// Sequentially samples all random values needed to create <paramref name="amount"/> EVs.
+    /// Must be called before <see cref="Create(SampledEVParams, Time)"/> when creating EVs in parallel.
+    /// </summary>
+    /// <param name="amount">The number of EVs to sample parameters for.</param>
+    /// <returns>An array of <see cref="SampledEVParams"/> ready to be passed to <see cref="Create(SampledEVParams, Time)"/> .</returns>
+    public SampledEVParams[] SampleParams(int amount)
+    {
+        var parameters = new SampledEVParams[amount];
+        for (var i = 0; i < amount; i++)
+        {
+            parameters[i] = new SampledEVParams(
+                Config: EVModels.Models[_sampler.Sample(random)],
+                CurrCharge: NextFloatInRange(0.4f, 1f),
+                PriceSensPref: random.NextSingle(),
+                MinAcceptableCharge: NextFloatInRange(0.05f, 0.4f),
+                MaxPathDeviation: NextFloatInRange(5.0f, 30.0f),
+                SourceDest: samplersProvider.Current.SampleSourceToDest(random));
+        }
+
+        return parameters;
+    }
+
+    private Journey CreateJourney(Time departure, (Position Source, Position Destination) sourceDest)
+    {
+        var (source, destination) = sourceDest;
+        var queryResult = pointToPointRouter.QuerySingleDestination(
+            source.Longitude,
+            source.Latitude,
+            destination.Longitude,
+            destination.Latitude);
+
+        var path = Polyline6ToPoints.DecodePolyline(queryResult.Polyline);
+        return new Journey(departure, (Time)(uint)queryResult.Duration, queryResult.Distance, path);
+    }
+
+    /// <summary>
+    /// Scales a random value to be between <paramref name="min"/> and <paramref name="max"/>.
     /// </summary>
     /// <param name="min">Minimum value to sample from.</param>
     /// <param name="max">Maximum value to sample from.</param>

--- a/Engine/Vehicles/EVPopulator.cs
+++ b/Engine/Vehicles/EVPopulator.cs
@@ -14,6 +14,8 @@ public class EVPopulator(EVFactory evFactory, EVStore evStore, IEventScheduler e
 {
     /// <summary>
     /// Creates a specified number of EVs and schedules their spawning events over a given distribution window.
+    /// Random sampling is done sequentially upfront via <see cref="EVFactory.SampleParams"/>,
+    /// after which EV construction is parallelized over the router calls.
     /// </summary>
     /// <param name="amount">The amount of EVs to create.</param>
     /// <param name="distributionWindow">The time window over which to distribute the spawning events.</param>
@@ -21,16 +23,16 @@ public class EVPopulator(EVFactory evFactory, EVStore evStore, IEventScheduler e
     {
         var currentTime = eventScheduler.CurrentTime;
         var interval = distributionWindow / amount;
-
         var indexes = ArrayPool<int>.Shared.Rent(amount);
         try
         {
             if (evStore.TryAllocateParallel(amount, indexes))
             {
+                var sampledParams = evFactory.SampleParams(amount);
                 Parallel.For(0, amount, i =>
                 {
                     var departure = (uint)(currentTime + (i * interval));
-                    evStore.Get(indexes[i]) = evFactory.Create(departure);
+                    evStore.Get(indexes[i]) = evFactory.Create(sampledParams[i], departure);
                 });
             }
         }

--- a/Engine/Vehicles/EVPopulator.cs
+++ b/Engine/Vehicles/EVPopulator.cs
@@ -10,12 +10,8 @@ using System.Buffers;
 /// <param name="evFactory">The factory used to create new EV instances.</param>
 /// <param name="evStore">The store used to allocate and manage EV instances.</param>
 /// <param name="eventScheduler">The scheduler used to manage and execute events.</param>
-public class EVPopulator(EVFactory evFactory, EVStore evStore, EventScheduler eventScheduler)
+public class EVPopulator(EVFactory evFactory, EVStore evStore, IEventScheduler eventScheduler)
 {
-    private readonly EVFactory _evFactory = evFactory;
-    private readonly EVStore _eVStore = evStore;
-    private readonly EventScheduler _eventScheduler = eventScheduler;
-
     /// <summary>
     /// Creates a specified number of EVs and schedules their spawning events over a given distribution window.
     /// </summary>
@@ -23,18 +19,18 @@ public class EVPopulator(EVFactory evFactory, EVStore evStore, EventScheduler ev
     /// <param name="distributionWindow">The time window over which to distribute the spawning events.</param>
     public void CreateEVs(int amount, Time distributionWindow)
     {
-        var currentTime = _eventScheduler.CurrentTime;
+        var currentTime = eventScheduler.CurrentTime;
         var interval = distributionWindow / amount;
 
         var indexes = ArrayPool<int>.Shared.Rent(amount);
         try
         {
-            if (_eVStore.TryAllocateParallel(amount, indexes))
+            if (evStore.TryAllocateParallel(amount, indexes))
             {
                 Parallel.For(0, amount, i =>
                 {
                     var departure = (uint)(currentTime + (i * interval));
-                    _eVStore.Get(indexes[i]) = _evFactory.Create(departure);
+                    evStore.Get(indexes[i]) = evFactory.Create(departure);
                 });
             }
         }

--- a/Tests/Engine.test/Builders/TestData.cs
+++ b/Tests/Engine.test/Builders/TestData.cs
@@ -17,6 +17,7 @@ using Engine.Metrics;
 using Engine.Vehicles;
 using Engine.Events;
 using Engine.Services;
+using Engine.Spawning;
 
 /// <summary>
 /// Ugly file for construction of objects more easily where we do not have to specifiy all properties or think about paths.
@@ -34,17 +35,42 @@ public static class TestData
 
     public static Dictionary<ushort, Station> AllStations => _allStations ??= CreateAllStations();
 
-    public static OSRMRouter OSRMRouter
-    {
-        get
-        {
-            return new OSRMRouter(
-                new FileInfo(AppContext.GetData("OsrmDataPath") as string
-                        ?? throw new InvalidDataException("OSRMPath not set")), [.. AllStations.Values]);
-        }
-    }
+    public static OSRMRouter OSRMRouter => new(
+                            new FileInfo(AppContext.GetData("OsrmDataPath") as string
+                                    ?? throw new InvalidDataException("OSRMPath not set")), [.. AllStations.Values]);
 
     public static readonly SpatialGrid SpatialGrid = BuildSpatialGrid(AllStations);
+
+    public static readonly JourneyPipeline JourneySamplers = BuildJourneyPipeline();
+
+    private static JourneyPipeline BuildJourneyPipeline()
+    {
+        var polygonPath = AppContext.GetData("GridPath") as string
+                    ?? throw new InvalidOperationException("GridPath not set in project.");
+
+        var polygons = PolygonParser.Parse(File.ReadAllText(polygonPath));
+        var spawnGrid = Polygooner.GenerateGrid(size: 0.1, polygons);
+
+        var cityPath = AppContext.GetData("CityDataPath") as string
+                            ?? throw new InvalidOperationException("GridPath not set in project.");
+
+        var cities = InitCities(new FileInfo(cityPath));
+
+        return new JourneyPipeline(spawnGrid, cities, OSRMRouter);
+    }
+
+    private static List<City> InitCities(FileInfo citiesPath)
+    {
+        return [.. File.ReadAllLines(citiesPath.ToString()).Skip(1).Select(line =>
+        {
+            var parts = line.Split(',');
+            var name = parts[0];
+            var longitude = double.Parse(parts[2]);
+            var latitude = double.Parse(parts[3]);
+            var population = int.Parse(parts[1]);
+            return new City(name, new Position(longitude, latitude), population);
+        })];
+    }
 
     public static MetricsService MetricsService()
     {
@@ -55,13 +81,14 @@ public static class TestData
     public static SnapshotEventHandler SnapshotHandler(
         MetricsService metrics,
         EventScheduler scheduler,
-        Dictionary<ushort, Station> stations,
-        int evStoreCapacity = 10) =>
-        new(
+        Dictionary<ushort, Station> stations)
+    {
+        return new(
             rescheduleTime: new Time(3600),
             stations: stations,
             metrics: metrics,
             scheduler: scheduler);
+    }
 
     public static Station Station(
         ushort id,
@@ -84,8 +111,8 @@ public static class TestData
         return new Station(id, string.Empty, string.Empty, position, chargerList, prices);
     }
 
-    public static Dictionary<ushort, Station> Stations(params (ushort Id, double Lon, double Lat)[] stations) =>
-        stations.ToDictionary(s => s.Id, s => Station(s.Id, new Position(s.Lon, s.Lat)));
+    public static Dictionary<ushort, Station> Stations(params (ushort Id, double Lon, double Lat)[] stations)
+        => stations.ToDictionary(s => s.Id, s => Station(s.Id, new Position(s.Lon, s.Lat)));
 
     public static SpatialGrid BuildSpatialGrid(Dictionary<ushort, Station>? stations = null)
     {
@@ -116,14 +143,12 @@ public static class TestData
         ushort capacity = 100,
         ushort maxChargeRate = 150,
         float stateOfCharge = 0.2f,
-        Socket socket = Socket.CCS2) =>
-        new(capacity, maxChargeRate, stateOfCharge, socket);
+        Socket socket = Socket.CCS2) => new(capacity, maxChargeRate, stateOfCharge, socket);
 
     public static Preferences Preferences(
         float PriceSensitivity = 1f,
         float MinAcceptableCharge = 0.1f,
-        float MaxPathDeviation = 10.0f) =>
-        new(PriceSensitivity, MinAcceptableCharge, MaxPathDeviation);
+        float MaxPathDeviation = 10.0f) => new(PriceSensitivity, MinAcceptableCharge, MaxPathDeviation);
 
     public static EV EV(
         List<Position>? waypoints = null,
@@ -131,12 +156,14 @@ public static class TestData
         Preferences? preferences = null,
         ushort efficiency = 150,
         uint originalDuration = 100u,
-        Time departureTime = default) =>
-        new(
+        Time departureTime = default)
+    {
+        return new(
             battery ?? Battery(),
             preferences ?? Preferences(),
             Journey(waypoints, originalDuration: originalDuration, departure: departureTime),
             efficiency);
+    }
 
     public static SingleCharger SingleCharger(int id, int maxPowerKW = 150)
     {
@@ -187,7 +214,7 @@ public static class TestData
     {
         private readonly float _fixedPrice = fixedPrice;
 
-        public new float CalculatePrice(DayOfWeek day, int hour) => _fixedPrice;
+        public float CalculatePrice() => _fixedPrice;
     }
 
     internal sealed class StubCostStore(CostWeights weights) : ICostStore
@@ -205,13 +232,19 @@ public static class TestData
     {
         private readonly Dictionary<ushort, Station> _stations = stations;
 
-        public Station GetStation(ushort stationId) => _stations.TryGetValue(stationId, out var station)
+        public Station GetStation(ushort stationId)
+        {
+            return _stations.TryGetValue(stationId, out var station)
             ? station
             : throw new KeyNotFoundException($"Station {stationId} not found.");
+        }
 
-        public int GetTotalQueueSize(ushort stationId) => _stations.TryGetValue(stationId, out var station)
+        public int GetTotalQueueSize(ushort stationId)
+        {
+            return _stations.TryGetValue(stationId, out var station)
             ? station.Chargers.Sum(c => c.Queue.Count)
             : throw new KeyNotFoundException($"Station {stationId} not found.");
+        }
     }
 
     private sealed class FakeCharger() : ChargerBase(id: 1, maxPowerKW: 100)

--- a/Tests/Engine.test/Vehicles/EVPopulatorTests.cs
+++ b/Tests/Engine.test/Vehicles/EVPopulatorTests.cs
@@ -1,0 +1,47 @@
+namespace Engine.test.Vehicles;
+
+using Core.Shared;
+using Engine.Events;
+using Engine.Spawning;
+using Engine.test.Builders;
+using Engine.Vehicles;
+
+public class EVPopulatorTests
+{
+    [Fact]
+    public void CreateEVsSameObjects2Iterations()
+    {
+        var journeySamplerProvider = new JourneySamplerProvider(TestData.JourneySamplers);
+        var fakeScheduler = new FakeScheduler();
+        var evStore1 = new EVStore(100);
+        var evStore2 = new EVStore(100);
+
+        var evPopulator1 = new EVPopulator(new EVFactory(new Random(1), journeySamplerProvider, TestData.OSRMRouter), evStore1, fakeScheduler);
+        var evPopulator2 = new EVPopulator(new EVFactory(new Random(1), journeySamplerProvider, TestData.OSRMRouter), evStore2, fakeScheduler);
+
+        evPopulator1.CreateEVs(100, 3600);
+        evPopulator2.CreateEVs(100, 3600);
+
+        for (var i = 0; i < 100; i++)
+        {
+            Assert.Equal(evStore1.Get(i).ToString(), evStore2.Get(i).ToString());
+        }
+    }
+
+    private class FakeScheduler : IEventScheduler
+    {
+        public Time CurrentTime = 0;
+
+        public List<Event> Events = [];
+
+        private uint _count = 0;
+
+        Time IEventScheduler.CurrentTime => CurrentTime;
+
+        public uint ScheduleEvent(Event e)
+        {
+            Events.Append(e);
+            return _count++;
+        }
+    }
+}


### PR DESCRIPTION
- **Confirmed that parallel CreateEVs is currently not deterministic**
- **Made a thread/parallel safe version of EVFactory Create**

# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #181

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
We initially thought the EVPopulator was thread safe. It wasn't as sampling in parallel lead to different attributes depending on the specific execution. This PR introduces a few new methods on the EVFactory that enables sampling all random values up front and can then execute OSRM routing on those values in parallel which is the expensive part. 

This will make it easier to find bugs and is to my knowledge the only place in the program that we need to make such changes to grantee reproducibility.
## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->
If you read the 2 commits individually you will find that i created a test which confirmed the problem and the second commit fixes the issue. I think we should merge this rather than squash.

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [X] All new and modified code has been tested (explain in Notes if not tested)  
- [X] Self-review completed  
