### PR TITLE
Fixed duration can't be 0

### DIFF
--- a/Engine/Grid/JourneySamplers.cs
+++ b/Engine/Grid/JourneySamplers.cs
@@ -2,6 +2,7 @@ namespace Engine.Grid;
 
 using Core.Shared;
 using Engine.Spawning;
+using Core.GeoMath;
 
 /// <summary>
 /// Defines the interface for sampling journeys, which includes sampling a source and destination position for a journey.
@@ -47,11 +48,18 @@ public class JourneySamplers(
     /// <returns>A tuple containing the source and destination positions.</returns>
     public (Position Source, Position Destination) SampleSourceToDest(Random random)
     {
-        var sourceIndex = _sourceSampler.Sample(random);
-        var source = SampleInCell(random, sourceIndex);
+        var distance = 0.0;
+        var dest = new Position(0, 0);
+        var source = new Position(0, 0);
+        while (distance < 0.5)
+        {
+            var sourceIndex = _sourceSampler.Sample(random);
+            source = SampleInCell(random, sourceIndex);
 
-        var destIndex = _destinationSamplers[sourceIndex].Sample(random);
-        var dest = _cityCenters[destIndex];
+            var destIndex = _destinationSamplers[sourceIndex].Sample(random);
+            dest = _cityCenters[destIndex];
+            distance = GeoMath.EquirectangularDistance(source, dest);
+        }
 
         return (source, dest);
     }

--- a/Headless/Program.cs
+++ b/Headless/Program.cs
@@ -50,7 +50,7 @@ public static class Program
                 RecordChargerSnapshots = true,
             },
 
-            Seed = new Random(1234),
+            Seed = new Random(42),
 
             StationFactoryOptions = new StationFactoryOptions
             {


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #200 

## Description of Implementation (optional)
This resolves the issue of the duration Can be zero throw (can't be zero). We not explicit ensure that a journey has a length of at least 500 meters. 

## Notes
I changed the seed back to 42 :seedling: 

Also we're currently resolving the bug of no candidate stations can be found due to ferries being an issue as EVs can be in the middle of a journey (on the ferry) when they try to find candidate stations resulting in the throw.

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
