### PR TITLE
Adjusted path deviation to int, and renabled charger metrics in engin…

### DIFF
--- a/Core/Routing/Journey.cs
+++ b/Core/Routing/Journey.cs
@@ -31,7 +31,7 @@ public record CurrentJourney(
     float DistanceKm,
     List<Position> Waypoints,
     Position NextStop,
-    Time PathDeviation,
+    int PathDeviation,
     Time DurationToNextStop)
 {
     /// <summary>Gets the current estimated time of arrival.</summary>
@@ -120,7 +120,7 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
         CheckTime(departure, checkBeforeDeparture: true, checkAfterCompletion: false, checkAfterEtaToNextStop: false);
         var deviation = Current.PathDeviation + (departure + duration) - Current.Eta;
         var durationToNextStop = DurationToNextStop(duration, waypoints, nextStop);
-        Current = new CurrentJourney(departure, duration, newDistanceKm, waypoints, nextStop, deviation, durationToNextStop);
+        Current = new CurrentJourney(departure, duration, newDistanceKm, waypoints, nextStop, (int)deviation, durationToNextStop);
     }
 
     /// <summary>

--- a/Engine/Cost/ComputeCost.cs
+++ b/Engine/Cost/ComputeCost.cs
@@ -65,7 +65,6 @@ public class CostFunction(ICostStore costStore, IStationService stationService, 
     // TODO: Think about effective queue size
     private float CalculateEffectiveQueueSizeCost(Station station, CostWeights weights)
     {
-
         var totalQueueSize = stationService.GetStation(station.Id)
                                 .Chargers.Sum(cs => cs.Queue.Count);
 

--- a/Engine/Init/EngineConfiguration.cs
+++ b/Engine/Init/EngineConfiguration.cs
@@ -39,6 +39,7 @@ public static class EngineConfiguration
                 RecordCarSnapshots = true,
                 RecordArrivals = true,
                 RecordStationSnapshots = true,
+                RecordChargerSnapshots = true,
             },
             StationFactoryOptions = new StationFactoryOptions
             {

--- a/Engine/Init/Init.cs
+++ b/Engine/Init/Init.cs
@@ -109,8 +109,6 @@ public static class Init
             return new EVFactory(random, journeySamplerProvider, router);
         });
 
-
-
         services.AddSingleton(sp =>
         {
             var settings = sp.GetRequiredService<EngineSettings>();
@@ -139,8 +137,6 @@ public static class Init
             var stationService = sp.GetRequiredService<StationService>();
             return new FindCandidateStationService(router, stations, grid, evStore, stationService);
         });
-
-
 
         services.AddSingleton(sp =>
         {

--- a/Engine/Metrics/Events/ArrivalAtDestinationMetric.cs
+++ b/Engine/Metrics/Events/ArrivalAtDestinationMetric.cs
@@ -21,12 +21,12 @@ public readonly struct ArrivalAtDestinationMetric
     /// <summary>
     /// Gets the path deviation for a journey.
     /// </summary>
-    required public uint PathDeviation { get; init; }
+    required public int PathDeviation { get; init; }
 
     /// <summary>
     /// Gets the difference between actual and expected arrival time.
     /// </summary>
-    public uint DeltaArrivalTime => ActualArrivalTime - ExpectedArrivalTime;
+    public int DeltaArrivalTime => (int)ActualArrivalTime - (int)ExpectedArrivalTime;
 
     /// <summary>
     /// Gets a value indicating whether the expected arrival time was missed.

--- a/Tests/Engine.test/Events/ArriveAtDestinationMetricTest.cs
+++ b/Tests/Engine.test/Events/ArriveAtDestinationMetricTest.cs
@@ -16,7 +16,7 @@ public class ArriveAtDestinationMetricTest
     {
         var departure = 100000U;
         var originalDuration = 50000U;
-        var deviation = 12000U;
+        var deviation = 12000;
         var simNow = (Time)(departure + originalDuration + deviation);
 
         var battery = CoreTestData.Battery();


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes # nothing

## Description of Implementation (optional)
I renabled charger snapshot metrics and adjusted path deviation to use int instead of uint as sometimes I believe OSRM may result in a shorter journey than previous meaning it could be negative in some cases.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
