### PR TITLE
enabled WaitTimeInQueue metrics

### DIFF
--- a/Engine/Init/EngineConfiguration.cs
+++ b/Engine/Init/EngineConfiguration.cs
@@ -34,10 +34,10 @@ public static class EngineConfiguration
             RunId = Guid.NewGuid(),
             MetricsConfig = new MetricsConfig
             {
-                BufferSize = 5000,
+                BufferSize = 3000,
                 OutputDirectory = outputPath,
-                RecordCarSnapshots = true,
                 RecordArrivals = true,
+                RecordEVWaitTimeInQueue = true,
                 RecordStationSnapshots = true,
                 RecordChargerSnapshots = true,
             },

--- a/Engine/Metrics/Events/EVWaitTimeInQueue.cs
+++ b/Engine/Metrics/Events/EVWaitTimeInQueue.cs
@@ -1,7 +1,5 @@
 namespace Engine.Metrics.Events;
 
-using Core.Shared;
-
 /// <summary>
 /// Represents a metric captured when an EV stops waiting in a queue and begins a charging session.
 /// </summary>
@@ -14,11 +12,11 @@ public record WaitTimeInQueueMetric
     required public ushort StationId { get; init; }
 
     /// <summary> Gets the simulation time when the EV arrived at the station. </summary>
-    required public Time ArrivalAtStationTime { get; init; }
+    required public uint ArrivalAtStationTime { get; init; }
 
     /// <summary> Gets the simulation time when the EV started charging. </summary>
-    required public Time StartChargingTime { get; init; }
+    required public uint StartChargingTime { get; init; }
 
     /// <summary> Gets the total time the EV spent waiting in the queue before starting to charge. </summary>
-    public Time WaitTime => StartChargingTime - ArrivalAtStationTime;
+    public uint WaitTimeInQueue => StartChargingTime - ArrivalAtStationTime;
 }

--- a/Engine/Metrics/MetricsConfig.cs
+++ b/Engine/Metrics/MetricsConfig.cs
@@ -11,9 +11,6 @@ public sealed class MetricsConfig
     /// <summary>Gets the output directory for metric files.</summary>
     public DirectoryInfo OutputDirectory { get; init; } = new DirectoryInfo("metrics");
 
-    /// <summary>Gets a value indicating whether car snapshots are recorded.</summary>
-    public bool RecordCarSnapshots { get; init; }
-
     /// <summary>Gets a value indicating whether station snapshots are recorded.</summary>
     public bool RecordStationSnapshots { get; init; }
 
@@ -30,5 +27,5 @@ public sealed class MetricsConfig
     public bool RecordArrivals { get; init; }
 
     /// <summary> Gets a value indicating whether EV wait time metric are recorded. </summary>
-    public bool RecordEVWaitTime { get; init; }
+    public bool RecordEVWaitTimeInQueue { get; init; }
 }

--- a/Engine/Metrics/MetricsService.cs
+++ b/Engine/Metrics/MetricsService.cs
@@ -19,11 +19,10 @@ using Engine.Metrics.Snapshots;
 /// </summary>
 public sealed class MetricsService : IAsyncDisposable
 {
-    private readonly IMetricWriter<EVSnapshotMetric>? _cars;
     private readonly IMetricWriter<ArrivalAtDestinationMetric>? _arrivals;
     private readonly IMetricWriter<StationSnapshotMetric>? _stations;
     private readonly IMetricWriter<ChargerSnapshotMetric>? _chargers;
-    private readonly IMetricWriter<WaitTimeInQueueMetric>? _waitTime;
+    private readonly IMetricWriter<WaitTimeInQueueMetric>? _waitTimeInQueue;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MetricsService"/> class.
@@ -35,21 +34,15 @@ public sealed class MetricsService : IAsyncDisposable
     {
         var files = new MetricsFileManager(config.OutputDirectory, runId);
 
-        if (config.RecordCarSnapshots)
-            _cars = new MetricWriter<EVSnapshotMetric>(config.BufferSize, files.GetMetricPath<EVSnapshotMetric>());
         if (config.RecordArrivals)
             _arrivals = new MetricWriter<ArrivalAtDestinationMetric>(config.BufferSize, files.GetMetricPath<ArrivalAtDestinationMetric>());
         if (config.RecordStationSnapshots)
             _stations = new MetricWriter<StationSnapshotMetric>(config.BufferSize, files.GetMetricPath<StationSnapshotMetric>());
         if (config.RecordChargerSnapshots)
             _chargers = new MetricWriter<ChargerSnapshotMetric>(config.BufferSize, files.GetMetricPath<ChargerSnapshotMetric>());
-        if (config.RecordEVWaitTime)
-            _waitTime = new MetricWriter<WaitTimeInQueueMetric>(config.BufferSize, files.GetMetricPath<WaitTimeInQueueMetric>());
+        if (config.RecordEVWaitTimeInQueue)
+            _waitTimeInQueue = new MetricWriter<WaitTimeInQueueMetric>(config.BufferSize, files.GetMetricPath<WaitTimeInQueueMetric>());
     }
-
-    /// <summary>Records a car snapshot. No-op if car snapshots are disabled in config.</summary>
-    /// <param name="metric">The car snapshot metric to record.</param>
-    public void RecordCar(EVSnapshotMetric metric) => _cars?.Record(metric);
 
     /// <summary>Records an arrival metric. No-op if arrivals are disabled in config.</summary>
     /// <param name="metric">The arrival metric to record.</param>
@@ -65,7 +58,7 @@ public sealed class MetricsService : IAsyncDisposable
 
     /// <summary> Records an EV wait time metric. No-op if EV wait time metrics are disabled in config. </summary>
     /// <param name="metric">The EV wait time metric to record.</param>
-    public void RecordWaitTime(WaitTimeInQueueMetric metric) => _waitTime?.Record(metric);
+    public void RecordWaitTime(WaitTimeInQueueMetric metric) => _waitTimeInQueue?.Record(metric);
 
     /// <summary>
     /// Signals all writers to stop, drains their channels, and flushes remaining
@@ -75,11 +68,10 @@ public sealed class MetricsService : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         var tasks = new List<Task>();
-        if (_cars is not null) tasks.Add(_cars.DisposeAsync().AsTask());
         if (_stations is not null) tasks.Add(_stations.DisposeAsync().AsTask());
         if (_chargers is not null) tasks.Add(_chargers.DisposeAsync().AsTask());
         if (_arrivals is not null) tasks.Add(_arrivals.DisposeAsync().AsTask());
-        if (_waitTime is not null) tasks.Add(_waitTime.DisposeAsync().AsTask());
+        if (_waitTimeInQueue is not null) tasks.Add(_waitTimeInQueue.DisposeAsync().AsTask());
         await Task.WhenAll(tasks);
     }
 }

--- a/Tests/Engine.test/Metrics/MetricsServiceTests.cs
+++ b/Tests/Engine.test/Metrics/MetricsServiceTests.cs
@@ -1,7 +1,8 @@
 namespace Engine.test.Metrics;
 
+using Core.Shared;
 using Engine.Metrics;
-using Engine.Metrics.Snapshots;
+using Engine.Metrics.Events;
 using Parquet.Serialization;
 
 public class MetricsServiceIntegrationTests
@@ -16,17 +17,25 @@ public class MetricsServiceIntegrationTests
         {
             BufferSize = 3,
             OutputDirectory = _dir,
-            RecordCarSnapshots = true,
+            RecordEVWaitTimeInQueue = true,
         };
 
         await using (var service = new MetricsService(config, runId))
         {
             for (var i = 0; i < 5; i++)
-                service.RecordCar(new EVSnapshotMetric());
+            {
+                service.RecordWaitTime(new WaitTimeInQueueMetric
+                {
+                    EVId = i,
+                    StationId = 1,
+                    ArrivalAtStationTime = new Time(0),
+                    StartChargingTime = new Time(1),
+                });
+            }
         }
 
         var files = new MetricsFileManager(_dir, runId);
-        var results = await ParquetSerializer.DeserializeAsync<EVSnapshotMetric>(files.GetMetricPath<EVSnapshotMetric>().FullName);
+        var results = await ParquetSerializer.DeserializeAsync<WaitTimeRow>(files.GetMetricPath<WaitTimeInQueueMetric>().FullName);
         Assert.Equal(5, results.Count);
     }
 
@@ -38,15 +47,32 @@ public class MetricsServiceIntegrationTests
         {
             BufferSize = 3,
             OutputDirectory = _dir,
-            RecordCarSnapshots = false,
+            RecordEVWaitTimeInQueue = false,
         };
 
         await using (var service = new MetricsService(config, runId))
         {
-            service.RecordCar(new EVSnapshotMetric());
+            service.RecordWaitTime(new WaitTimeInQueueMetric
+            {
+                EVId = 1,
+                StationId = 1,
+                ArrivalAtStationTime = new Time(0),
+                StartChargingTime = new Time(1),
+            });
         }
 
         var files = new MetricsFileManager(_dir, runId);
-        Assert.False(files.GetMetricPath<EVSnapshotMetric>().Exists);
+        Assert.False(files.GetMetricPath<WaitTimeInQueueMetric>().Exists);
+    }
+
+    private sealed class WaitTimeRow
+    {
+        public int EVId { get; set; }
+
+        public ushort StationId { get; set; }
+
+        public Time ArrivalAtStationTime { get; set; }
+
+        public Time StartChargingTime { get; set; }
     }
 }

--- a/Tests/Engine.test/Metrics/WaitTimeMetricsTests.cs
+++ b/Tests/Engine.test/Metrics/WaitTimeMetricsTests.cs
@@ -19,8 +19,8 @@ public class WaitTimeMetricTests
             StartChargingTime = startCharge,
         };
 
-        var result = metric.WaitTime;
+        var result = metric.WaitTimeInQueue;
 
-        Assert.Equal(150u, result.Milliseconds);
+        Assert.Equal(150u, result);
     }
 }


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes # nothing

## Description of Implementation (optional)
This enables the WaitTimeInQueue metric. 

## Notes
We write the metric everytime we've recorded 3k instances. The buffer is arbitrary could be 5k as well as it also influences the arrivals. Seemed fine to me.

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
