### PR TITLE
Added the ability to run the simulation with cost weights from EVanlysis

### DIFF
--- a/Engine/Init/EngineConfiguration.cs
+++ b/Engine/Init/EngineConfiguration.cs
@@ -3,6 +3,7 @@ namespace Engine.Init;
 using Engine.Cost;
 using Engine.Metrics;
 using Engine.StationFactory;
+using System.Globalization;
 using System.Reflection;
 
 /// <summary>
@@ -11,6 +12,12 @@ using System.Reflection;
 /// </summary>
 public static class EngineConfiguration
 {
+    private const string _priceSensitivityEnvVar = "COST_WEIGHT_PRICE_SENSITIVITY";
+    private const string _pathDeviationEnvVar = "COST_WEIGHT_PATH_DEVIATION";
+    private const string _effectiveQueueSizeEnvVar = "COST_WEIGHT_EFFECTIVE_QUEUE_SIZE";
+    private const string _urgencyEnvVar = "COST_WEIGHT_URGENCY";
+    private const string _expectedWaitTimeEnvVar = "COST_WEIGHT_EXPECTED_WAIT_TIME";
+
     /// <summary>
     /// Creates default EngineSettings with the standard workspace configuration.
     /// </summary>
@@ -25,11 +32,11 @@ public static class EngineConfiguration
             Seed = new Random(42),
             CostConfig = new CostWeights
             {
-                EffectiveQueueSize = 1,
-                PathDeviation = 0.8f,
-                PriceSensitivity = 0.4f,
-                ExpectedWaitTime = 1,
-                Urgency = 0.5f,
+                EffectiveQueueSize = ReadWeightFromEnvironment(_effectiveQueueSizeEnvVar, 1f, 0f, 1f),
+                PathDeviation = ReadWeightFromEnvironment(_pathDeviationEnvVar, 0.8f, 0f, 1f),
+                PriceSensitivity = ReadWeightFromEnvironment(_priceSensitivityEnvVar, 0.4f, 0f, 1f),
+                ExpectedWaitTime = ReadWeightFromEnvironment(_expectedWaitTimeEnvVar, 1f, 0f, 1f),
+                Urgency = ReadWeightFromEnvironment(_urgencyEnvVar, 0.5f, 0f, 1f),
             },
             RunId = Guid.NewGuid(),
             MetricsConfig = new MetricsConfig
@@ -64,6 +71,18 @@ public static class EngineConfiguration
             PolygonPath = new FileInfo(Path.Combine(dataPath.FullName, "denmark_polygon.json")),
             WetPolygonPath = new FileInfo(Path.Combine(dataPath.FullName, "denmark_wet_polygon.json")),
         };
+    }
+
+    private static float ReadWeightFromEnvironment(string envVar, float defaultValue, float min, float max)
+    {
+        var value = Environment.GetEnvironmentVariable(envVar);
+        if (string.IsNullOrWhiteSpace(value))
+            return defaultValue;
+
+        if (!float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+            return defaultValue;
+
+        return Math.Clamp(parsed, min, max);
     }
 
     private static DirectoryInfo FindDataDirectory()


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes # not issue created

## Description of Implementation (optional)
Added the ability to run the simulation with cost weights from EVanlysis
Enables us to do random search and grid search with cost weights.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x]  Self-review completed  
