### PR TITLE
Added endpoints to stop/pause/unpause the simulation from the frontend

### DIFF
--- a/API/Program.cs
+++ b/API/Program.cs
@@ -150,7 +150,7 @@ public static class Program
             return Results.Ok(new { message = "Simulation paused successfully" });
         });
 
-        app.MapPost("/simulation/unpause", async (EngineManager.EngineManager engineManager) =>
+        app.MapPost("/simulation/resume", async (EngineManager.EngineManager engineManager) =>
         {
             if (!engineManager.IsInitialized)
                 return Results.BadRequest("Engine not initialized");

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -88,6 +88,57 @@ public static class Program
             return Results.Ok();
         });
 
+        app.MapPost("/simulation/stop", async (EngineManager.EngineManager engineManager) =>
+        {
+            if (!engineManager.IsInitialized)
+                return Results.BadRequest("Engine not initialized");
+
+            var simulationRunner = engineManager.GetEngineService<SimulationRunner>();
+
+            if (!simulationRunner.IsRunning)
+                return Results.BadRequest("Simulation is not running");
+
+            await simulationRunner.StopAsync();
+
+            return Results.Ok(new { message = "Simulation stopped successfully" });
+        });
+
+        app.MapPost("/simulation/pause", async (EngineManager.EngineManager engineManager) =>
+        {
+            if (!engineManager.IsInitialized)
+                return Results.BadRequest("Engine not initialized");
+
+            var simulationRunner = engineManager.GetEngineService<SimulationRunner>();
+
+            if (!simulationRunner.IsRunning)
+                return Results.BadRequest("Simulation is not running");
+
+            if (simulationRunner.IsPaused)
+                return Results.BadRequest("Simulation is already paused");
+
+            await simulationRunner.PauseAsync();
+
+            return Results.Ok(new { message = "Simulation paused successfully" });
+        });
+
+        app.MapPost("/simulation/unpause", async (EngineManager.EngineManager engineManager) =>
+        {
+            if (!engineManager.IsInitialized)
+                return Results.BadRequest("Engine not initialized");
+
+            var simulationRunner = engineManager.GetEngineService<SimulationRunner>();
+
+            if (!simulationRunner.IsRunning)
+                return Results.BadRequest("Simulation is not running");
+
+            if (!simulationRunner.IsPaused)
+                return Results.BadRequest("Simulation is not paused");
+
+            await simulationRunner.ResumeAsync();
+
+            return Results.Ok(new { message = "Simulation resumed successfully" });
+        });
+
         app.Map("/ws/simulation", async context =>
         {
             if (!context.WebSockets.IsWebSocketRequest)

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -124,7 +124,7 @@ public static class Program
 
             var simulationRunner = engineManager.GetEngineService<SimulationRunner>();
 
-            if (!simulationRunner.IsRunning)
+            if (simulationRunner.State == SimulationState.Stopped)
                 return Results.BadRequest("Simulation is not running");
 
             await simulationRunner.StopAsync();
@@ -139,10 +139,10 @@ public static class Program
 
             var simulationRunner = engineManager.GetEngineService<SimulationRunner>();
 
-            if (!simulationRunner.IsRunning)
+            if (simulationRunner.State == SimulationState.Stopped)
                 return Results.BadRequest("Simulation is not running");
 
-            if (simulationRunner.IsPaused)
+            if (simulationRunner.State == SimulationState.Paused)
                 return Results.BadRequest("Simulation is already paused");
 
             await simulationRunner.PauseAsync();
@@ -157,10 +157,10 @@ public static class Program
 
             var simulationRunner = engineManager.GetEngineService<SimulationRunner>();
 
-            if (!simulationRunner.IsRunning)
+            if (simulationRunner.State == SimulationState.Stopped)
                 return Results.BadRequest("Simulation is not running");
 
-            if (!simulationRunner.IsPaused)
+            if (simulationRunner.State != SimulationState.Paused)
                 return Results.BadRequest("Simulation is not paused");
 
             await simulationRunner.ResumeAsync();

--- a/API/Services/SimulationRunner.cs
+++ b/API/Services/SimulationRunner.cs
@@ -4,7 +4,7 @@ using Engine;
 
 /// <summary>
 /// Manages the execution of the simulation in a background task, allowing it to run concurrently with the API server.
-/// </summary> 
+/// </summary>
 /// <param name="simulation">The simulation instance to run.</param>
 /// <param name="logger">The logger for recording events and errors.</param>
 public sealed class SimulationRunner(
@@ -13,12 +13,18 @@ public sealed class SimulationRunner(
 {
     private Task? _simulationTask;
     private CancellationTokenSource? _cts;
+    private volatile bool _isPaused;
 
     /// <summary>
     /// Gets a value indicating whether the simulation is currently running.
-    /// </summary> 
+    /// </summary>
     /// <returns>True if the simulation is running; otherwise, false.</returns>
     public bool IsRunning => _simulationTask != null && !_simulationTask.IsCompleted;
+
+    /// <summary>
+    /// Gets a value indicating whether the simulation is currently paused.
+    /// </summary>
+    public bool IsPaused => _isPaused;
 
     /// <summary>
     /// Starts the simulation in a background task. If the simulation is already running, this method does nothing.
@@ -31,12 +37,15 @@ public sealed class SimulationRunner(
             return Task.CompletedTask;
 
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken);
+        _isPaused = false;
         _simulationTask = Task.Run(() => RunLoopAsync(_cts.Token), _cts.Token);
+
         return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Stops the simulation by signaling cancellation and awaiting the completion of the simulation task. If the simulation is not running, this method does nothing.
+    /// Stops the simulation by signalling cancellation and awaiting the completion of the simulation task.
+    /// If the simulation is not running, this method does nothing.
     /// </summary>
     /// <returns>A task representing the asynchronous operation that stops the simulation.</returns>
     public async Task StopAsync()
@@ -45,19 +54,58 @@ public sealed class SimulationRunner(
             return;
 
         _cts?.Cancel();
+
         if (_simulationTask != null)
             await _simulationTask;
 
         _cts?.Dispose();
         _cts = null;
         _simulationTask = null;
+        _isPaused = false;
+    }
+
+    /// <summary>
+    /// Pauses the simulation if it is currently running.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public Task PauseAsync()
+    {
+        if (!IsRunning)
+            return Task.CompletedTask;
+
+        _isPaused = true;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Resumes the simulation if it is currently running.
+    /// </summary>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public Task ResumeAsync()
+    {
+        if (!IsRunning)
+            return Task.CompletedTask;
+
+        _isPaused = false;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Waits while the simulation is paused.
+    /// </summary>
+    /// <param name="cancelToken">Cancellation token that stops the wait.</param>
+    /// <returns>A task representing the asynchronous wait operation.</returns>
+    private async Task WaitWhilePausedAsync(CancellationToken cancelToken)
+    {
+        while (_isPaused && !cancelToken.IsCancellationRequested)
+            await Task.Delay(100, cancelToken);
     }
 
     private async Task RunLoopAsync(CancellationToken cancelToken)
     {
         try
         {
-            await simulation.Run(cancelToken);
+            await simulation.Run(cancelToken, () => WaitWhilePausedAsync(cancelToken));
         }
         catch (OperationCanceledException)
         {

--- a/API/Services/SimulationRunner.cs
+++ b/API/Services/SimulationRunner.cs
@@ -5,6 +5,16 @@ using Core.Helper;
 using Engine;
 
 /// <summary>
+/// Represents the current execution state of the simulation.
+/// </summary>
+public enum SimulationState
+{
+    Stopped,
+    Running,
+    Paused,
+}
+
+/// <summary>
 /// Manages the execution of the simulation in a background task, allowing it to run concurrently with the API server.
 /// </summary>
 /// <param name="simulation">The simulation instance to run.</param>
@@ -13,31 +23,25 @@ public sealed class SimulationRunner(
 {
     private Task? _simulationTask;
     private CancellationTokenSource? _cts;
-    private volatile bool _isPaused;
+    private volatile int _state = (int)SimulationState.Stopped;
 
     /// <summary>
-    /// Gets a value indicating whether the simulation is currently running.
+    /// Gets the current state of the simulation.
     /// </summary>
-    /// <returns>True if the simulation is running; otherwise, false.</returns>
-    public bool IsRunning => _simulationTask?.IsCompleted is false;
+    public SimulationState State => (SimulationState)_state;
 
     /// <summary>
-    /// Gets a value indicating whether the simulation is currently paused.
-    /// </summary>
-    public bool IsPaused => _isPaused;
-
-    /// <summary>
-    /// Starts the simulation in a background task. If the simulation is already running, this method does nothing.
+    /// Starts the simulation in a background task. If the simulation is not stopped, this method does nothing.
     /// </summary>
     /// <param name="cancelToken">Cancellation token that will stop the simulation loop.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public Task StartAsync(CancellationToken cancelToken = default)
     {
-        if (IsRunning)
+        if (State != SimulationState.Stopped)
             return Task.CompletedTask;
 
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancelToken);
-        _isPaused = false;
+        _state = (int)SimulationState.Running;
         _simulationTask = Task.Run(() => RunLoopAsync(_cts.Token), _cts.Token);
 
         return Task.CompletedTask;
@@ -45,23 +49,18 @@ public sealed class SimulationRunner(
 
     /// <summary>
     /// Stops the simulation by signalling cancellation and awaiting the completion of the simulation task.
-    /// If the simulation is not running, this method does nothing.
+    /// If the simulation is already stopped, this method does nothing.
     /// </summary>
     /// <returns>A task representing the asynchronous operation that stops the simulation.</returns>
     public async Task StopAsync()
     {
-        if (!IsRunning)
+        if (State == SimulationState.Stopped)
             return;
 
         _cts?.Cancel();
 
         if (_simulationTask != null)
             await _simulationTask;
-
-        _cts?.Dispose();
-        _cts = null;
-        _simulationTask = null;
-        _isPaused = false;
     }
 
     /// <summary>
@@ -70,23 +69,23 @@ public sealed class SimulationRunner(
     /// <returns>A task representing the asynchronous operation.</returns>
     public Task PauseAsync()
     {
-        if (!IsRunning)
+        if (State != SimulationState.Running)
             return Task.CompletedTask;
 
-        _isPaused = true;
+        _state = (int)SimulationState.Paused;
         return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Resumes the simulation if it is currently running.
+    /// Resumes the simulation if it is currently paused.
     /// </summary>
     /// <returns>A task representing the asynchronous operation.</returns>
     public Task ResumeAsync()
     {
-        if (!IsRunning)
+        if (State != SimulationState.Paused)
             return Task.CompletedTask;
 
-        _isPaused = false;
+        _state = (int)SimulationState.Running;
         return Task.CompletedTask;
     }
 
@@ -97,7 +96,7 @@ public sealed class SimulationRunner(
     /// <returns>A task representing the asynchronous wait operation.</returns>
     private async Task WaitWhilePausedAsync(CancellationToken cancelToken)
     {
-        while (_isPaused && !cancelToken.IsCancellationRequested)
+        while (State == SimulationState.Paused && !cancelToken.IsCancellationRequested)
             await Task.Delay(100, cancelToken);
     }
 
@@ -113,7 +112,14 @@ public sealed class SimulationRunner(
         }
         catch (Exception ex)
         {
-            Log.Error(0, 0, ex);
+            Log.Error(0, 0, ex, ("message", "Error in SimulationRunner"));
+        }
+        finally
+        {
+            _cts?.Dispose();
+            _cts = null;
+            _simulationTask = null;
+            _state = (int)SimulationState.Stopped;
         }
     }
 }

--- a/Engine/Simulation.cs
+++ b/Engine/Simulation.cs
@@ -61,6 +61,10 @@ public class Simulation(
                 Log.Error(0, 0, ex);
                 Console.WriteLine($"Simulation crashed: {ex}");
             }
+            finally
+            {
+                await Serilog.Log.CloseAndFlushAsync();
+            }
         }
 
     /// <summary>

--- a/Engine/Simulation.cs
+++ b/Engine/Simulation.cs
@@ -12,7 +12,8 @@ using Engine.Events;
 /// <param name="runUntilStop">A Time that indicates when the simulation should stop.</param>
 public class Simulation(
     EventDispatcher dispatcher,
-    EventScheduler scheduler, Time runUntilStop)
+    EventScheduler scheduler,
+    Time runUntilStop)
 {
     /// <summary>
     /// Runs the simulation by scheduling initial events
@@ -20,8 +21,11 @@ public class Simulation(
     /// the specified end time is reached.
     /// </summary>
     /// <param name="cancelToken">A CancellationToken to allow graceful shutdown of the simulation.</param>
-    /// <returns>Returns?.</returns>
-    public async Task Run(CancellationToken cancelToken = default)
+    /// <param name="waitWhilePausedAsync">A callback that blocks progress while the simulation is paused.</param>
+    /// <returns>A task representing the asynchronous simulation run.</returns>
+    public async Task Run(
+        CancellationToken cancelToken = default,
+        Func<Task>? waitWhilePausedAsync = null)
     {
         Console.WriteLine("Starting Simulation");
         scheduler.ScheduleEvent(new SpawnEVS(0));
@@ -30,6 +34,10 @@ public class Simulation(
         while (true)
         {
             cancelToken.ThrowIfCancellationRequested();
+
+            if (waitWhilePausedAsync != null)
+                await waitWhilePausedAsync();
+
             var shouldContinue = await HandleNextEvent(cancelToken);
             if (!shouldContinue)
                 return;

--- a/Engine/Simulation.cs
+++ b/Engine/Simulation.cs
@@ -25,42 +25,43 @@ public class Simulation(
     /// <param name="waitWhilePausedAsync">A callback that blocks progress while the simulation is paused.</param>
     /// <returns>A task representing the asynchronous simulation run.</returns>
     public async Task Run(
-        CancellationToken cancelToken = default,
-        Func<Task>? waitWhilePausedAsync = null)
-    {
-        Log.Info(0, 0, "Simulation started.");
-        Console.WriteLine("Starting Simulation");
-
-        scheduler.ScheduleEvent(new SpawnEVS(0));
-        scheduler.ScheduleEvent(new SnapshotEvent(0));
-
-        try
+    CancellationToken cancelToken = default,
+    Func<Task>? waitWhilePausedAsync = null)
         {
-            while (true)
+            Log.Info(0, 0, "Simulation started.");
+            Console.WriteLine("Starting Simulation");
+
+            scheduler.ScheduleEvent(new SpawnEVS(0));
+            scheduler.ScheduleEvent(new SnapshotEvent(0));
+
+            try
             {
-                cancelToken.ThrowIfCancellationRequested();
-              
-                if (waitWhilePausedAsync != null)
-                await waitWhilePausedAsync();
-              
-                var shouldContinue = await HandleNextEvent(cancelToken);
-                if (!shouldContinue)
+                while (true)
                 {
-                    Log.Info(0, 0, "Simulation finished.");
-                    return;
+                    cancelToken.ThrowIfCancellationRequested();
+
+                    if (waitWhilePausedAsync != null)
+                        await waitWhilePausedAsync();
+
+                    var shouldContinue = await HandleNextEvent(cancelToken);
+                    if (!shouldContinue)
+                    {
+                        Log.Info(0, 0, "Simulation finished.");
+                        return;
+                    }
                 }
             }
+            catch (OperationCanceledException)
+            {
+                Log.Info(0, 0, "Simulation stopped.");
+                Console.WriteLine("Simulation stopped.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(0, 0, ex);
+                Console.WriteLine($"Simulation crashed: {ex}");
+            }
         }
-        catch (Exception ex)
-        {
-            Log.Warn(0, 0, "Simulation crashed.");
-            Console.WriteLine($"Simulation crashed: {ex}");
-        }
-        finally
-        {
-            await Serilog.Log.CloseAndFlushAsync();
-        }
-    }
 
     /// <summary>
     /// Handles the next event in the scheduler.


### PR DESCRIPTION
# Related Issues
Closes #47 

## Description of Implementation (optional)
This PR adds endpoints for stopping, pausing and unpausing the simulation through the frontend. 

## Notes
No new unit tests were added for this PR because the change is mainly endpoint wiring around existing simulation runner functionality. Instead it was tested by checking that when pressing the designated buttons on the frontend, the correct behaviour happened on the backend. 

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [ ] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
