### PR TITLE
Distribution of power on our stations

### DIFF
--- a/Engine/StationFactory/StationFactory.cs
+++ b/Engine/StationFactory/StationFactory.cs
@@ -36,8 +36,7 @@ public class StationFactory
         {
             throw Log.Error(0, 0, new ArgumentOutOfRangeException(
                 nameof(options.TotalChargers),
-                "TotalChargers must be greater than zero."),
-                ("TotalChargers", options.TotalChargers));
+                "TotalChargers must be greater than zero."));
         }
 
         if (options.DualChargingPointProbability < 0 || options.DualChargingPointProbability > 1)
@@ -45,6 +44,35 @@ public class StationFactory
             throw Log.Error(0, 0, new ArgumentOutOfRangeException(
                 nameof(options.DualChargingPointProbability),
                 "DualChargingPointProbability must be between 0 and 1."));
+        }
+
+        if (options.PowerOutputProbabilitiesKW is null || options.PowerOutputProbabilitiesKW.Count == 0)
+        {
+            throw Log.Error(0, 0, new ArgumentException(
+                "PowerOutputProbabilitiesKW must contain at least one value.",
+                nameof(options.PowerOutputProbabilitiesKW)));
+        }
+
+        if (options.PowerOutputProbabilitiesKW.Any(x => x.Key == 0))
+        {
+            throw Log.Error(0, 0, new ArgumentException(
+                "PowerOutputProbabilitiesKW must only contain power outputs greater than zero.",
+                nameof(options.PowerOutputProbabilitiesKW)));
+        }
+
+        if (options.PowerOutputProbabilitiesKW.Any(x => x.Value < 0))
+        {
+            throw Log.Error(0, 0, new ArgumentException(
+                "PowerOutputProbabilitiesKW must only contain non-negative probabilities.",
+                nameof(options.PowerOutputProbabilitiesKW)));
+        }
+
+        var totalProbability = options.PowerOutputProbabilitiesKW.Values.Sum();
+        if (Math.Abs(totalProbability - 1.0) > 0.0001)
+        {
+            throw Log.Error(0, 0, new ArgumentException(
+                $"PowerOutputProbabilitiesKW must sum to 1. Current sum: {totalProbability}.",
+                nameof(options.PowerOutputProbabilitiesKW)));
         }
 
         _options = options;
@@ -72,7 +100,8 @@ public class StationFactory
         if (locations.Count == 0)
             throw Log.Error(0, 0, new InvalidOperationException("Station locations JSON file was empty."));
 
-        var chargerCountsPerStation = DistributeChargersAcrossStations(locations.Count, _options.TotalChargers) ?? throw Log.Error(0, 0, new InvalidOperationException("Failed to distribute chargers across stations."));
+        var chargerCountsPerStation = DistributeChargersAcrossStations(locations.Count, _options.TotalChargers)
+            ?? throw Log.Error(0, 0, new InvalidOperationException("Failed to distribute chargers across stations."));
 
         var stations = new List<Station>(locations.Count);
         ushort nextStationId = 0;
@@ -85,13 +114,15 @@ public class StationFactory
 
             for (var j = 0; j < chargerCount; j++)
             {
-                chargers.Add(CreateCharger(chargerId++));
+                var charger = CreateCharger(chargerId++);
+                chargers.Add(charger);
             }
 
             stations.Add(CreateStation(nextStationId++, locations[i], chargers));
         }
 
         Log.Info(0, 0, $"Created {stations.Count} stations with a total of {chargerId - 1} chargers.");
+
         return stations;
     }
 
@@ -127,21 +158,41 @@ public class StationFactory
     /// </returns>
     private ChargerBase CreateCharger(int chargerId)
     {
-        var connectors = CreateConnectorSet();
+        var powerOutputKW = GetRandomPowerOutputKW();
+        var connectors = CreateConnectorSet(powerOutputKW);
 
         if (ShouldCreateDualChargingPoint())
         {
-            return new DualCharger(chargerId, _options.MaxPowerKW, connectors);
+            return new DualCharger(chargerId, powerOutputKW, connectors);
         }
 
-        return new SingleCharger(chargerId, _options.MaxPowerKW, connectors);
+        return new SingleCharger(chargerId, powerOutputKW, connectors);
     }
 
-    private Connectors CreateConnectorSet()
-        => new((new Connector(_options.MaxPowerKW), new Connector(_options.MaxPowerKW)));
+    private Connectors CreateConnectorSet(ushort powerOutputKW)
+        => new((new Connector(powerOutputKW), new Connector(powerOutputKW)));
 
     private bool ShouldCreateDualChargingPoint()
         => _random.NextDouble() < _options.DualChargingPointProbability;
+
+    private ushort GetRandomPowerOutputKW()
+    {
+        var randomValue = _random.NextDouble();
+        var cumulativeProbability = 0.0;
+
+        foreach (var (powerOutputKW, probability) in _options.PowerOutputProbabilitiesKW)
+        {
+            cumulativeProbability += probability;
+
+            if (randomValue < cumulativeProbability)
+            {
+                return powerOutputKW;
+            }
+        }
+
+        // Fallback for floating-point edge cases.
+        return _options.PowerOutputProbabilitiesKW.Last().Key;
+    }
 
     /// <summary>
     /// Distributes the total number of chargers across the available stations.

--- a/Engine/StationFactory/StationFactoryOptions.cs
+++ b/Engine/StationFactory/StationFactoryOptions.cs
@@ -1,5 +1,3 @@
-namespace Engine.StationFactory;
-
 /// <summary>
 /// Options controlling deterministic station generation behaviour.
 /// </summary>
@@ -23,7 +21,18 @@ public record StationFactoryOptions
     public int TotalChargers { get; init; } = 10000;
 
     /// <summary>
-    /// Gets the maximum power in kilowatts that a charger can deliver, which affects how quickly EVs can charge and how long they spend at charging stations.
+    /// Gets the probability distribution for charger power outputs in kW.
+    /// The probabilities should sum to 1.
     /// </summary>
-    public ushort MaxPowerKW { get; init; } = 400;
+    /// <remarks>
+    /// These probabilites are based on our dataset. The probabilities are calculated on only the amount of chargers
+    /// with over 100 kW power output so all stations with less have been excluded. 
+    /// </remarks>
+    public IReadOnlyDictionary<ushort, double> PowerOutputProbabilitiesKW { get; init; }
+        = new Dictionary<ushort, double>
+        {
+            { 120, 0.0085 },
+            { 150, 0.1010 },
+            { 400, 0.8905 },
+        };
 }

--- a/Engine/StationFactory/StationLocationDTO.cs
+++ b/Engine/StationFactory/StationLocationDTO.cs
@@ -5,9 +5,6 @@ namespace Engine.StationFactory;
 /// </summary>
 public class StationLocationDTO
 {
-    /// <summary> Gets or sets the name of the station location. </summary>
-    public string Name { get; set; } = string.Empty;
-
     /// <summary> Gets or sets the address of the station location. </summary>
     public string Address { get; set; } = string.Empty;
 


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes # none. 

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
Introduces different power outputs for our stations. The power is distributed between stations based on a probability that is calculated from our dataset on chargers in Denmark. I have only used power outputs of 120, 150 and 400 and have excluded the ones for 43 as I felt it was too low a power output. Might be worth adjusting the probabilities slightly for more spread of power outputs but that adjustment would have no "factual" backing behind it. 

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->
Tested visually through the frontend 

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [ ] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  