### PR TITLE
Allows the start time to be configured. Might need python binding

### DIFF
--- a/API/EngineManager/EngineInitConfigDTO.cs
+++ b/API/EngineManager/EngineInitConfigDTO.cs
@@ -1,5 +1,7 @@
 namespace API.EngineManager;
 
+using Core.Shared;
+
 public record CostWeightDTO(int CostId, double Value);
 
 public record EngineInitConfigDTO(
@@ -7,4 +9,6 @@ public record EngineInitConfigDTO(
     int Seed,
     List<CostWeightDTO> CostWeights,
     double DualChargerProbability,
-    int NumberOfChargers);
+    int NumberOfChargers,
+    uint StartTime = Time.MillisecondsPerDay,
+    uint EndTime = Time.MillisecondsPerDay * 7);

--- a/API/EngineManager/EngineManager.cs
+++ b/API/EngineManager/EngineManager.cs
@@ -69,6 +69,8 @@ public class EngineManager
                 TotalChargers = configDTO.NumberOfChargers
             },
             CostConfig = configDTO.CostWeights.ToDomain(defaultSettings.CostConfig),
+            SimulationStartTime = configDTO.StartTime,
+            SimulationEndTime = configDTO.EndTime
         };
     }
 

--- a/Engine/Init/EngineConfiguration.cs
+++ b/Engine/Init/EngineConfiguration.cs
@@ -6,6 +6,7 @@ using Engine.StationFactory;
 using System.Globalization;
 using System.Reflection;
 using Core.Helper;
+using Core.Shared;
 
 /// <summary>
 /// Factory for creating EngineSettings with default configuration.
@@ -16,7 +17,6 @@ public static class EngineConfiguration
     private const string _priceSensitivityEnvVar = "COST_WEIGHT_PRICE_SENSITIVITY";
     private const string _pathDeviationEnvVar = "COST_WEIGHT_PATH_DEVIATION";
     private const string _effectiveQueueSizeEnvVar = "COST_WEIGHT_EFFECTIVE_QUEUE_SIZE";
-    private const string _urgencyEnvVar = "COST_WEIGHT_URGENCY";
     private const string _expectedWaitTimeEnvVar = "COST_WEIGHT_EXPECTED_WAIT_TIME";
 
     /// <summary>
@@ -56,7 +56,8 @@ public static class EngineConfiguration
             },
             CurrentAmountOfEVsInDenmark = 583320, // Based on the number of registered EVs in Denmark as of 2026-03-22 https://mobility.dk/nyheder/nu-koerer-hver-femte-personbil-i-danmark-paa-el/
             ChargingStepSeconds = 60 * 1000,
-            SimulationEndTime = 10000 * 60 * 1000,
+            SimulationStartTime = Time.MillisecondsPerDay,
+            SimulationEndTime = Time.MillisecondsPerDay * 7,
             SnapshotInterval = 1000 * 20 * 60,
             EVDistributionWindowsSize = 1 * 60 * 1000,
             EVSpawnFraction = 0.10f,

--- a/Engine/Init/EngineSettings.cs
+++ b/Engine/Init/EngineSettings.cs
@@ -64,7 +64,13 @@ public record EngineSettings
     /// Gets the simulation end time, which determines
     /// when the simulation should stop running.
     /// </summary>
-    required public Time SimulationEndTime { get; init; }
+    required public Time SimulationEndTime { get; init; } = Time.MillisecondsPerDay * 7;
+
+    /// <summary>
+    /// Gets the simulation start time,
+    /// which determines when the simulation starts.
+    /// </summary>
+    required public Time SimulationStartTime { get; init; } = Time.MillisecondsPerDay;
 
     /// <summary>
     /// Gets the size of the windows in which EVs are spawned, which affects the distribution of EV arrivals over time.

--- a/Engine/Init/Init.cs
+++ b/Engine/Init/Init.cs
@@ -211,8 +211,9 @@ public static class Init
             var scheduler = sp.GetRequiredService<EventScheduler>();
             var dispatcher = sp.GetRequiredService<EventDispatcher>();
             var settings = sp.GetRequiredService<EngineSettings>();
-            var simulationEndTime = settings.SimulationEndTime;
-            return new Simulation(dispatcher, scheduler, simulationEndTime);
+            var startTime = settings.SimulationStartTime;
+            var endTime = settings.SimulationEndTime;
+            return new Simulation(dispatcher, scheduler, startTime, endTime);
         });
 
         services.AddSingleton(sp =>

--- a/Engine/Simulation.cs
+++ b/Engine/Simulation.cs
@@ -8,14 +8,35 @@ using Core.Helper;
 /// The Simulation class is responsible for running the simulation by continuously fetching and
 /// handling events from the EventScheduler until a specified end time is reached.
 /// </summary>
-/// <param name="dispatcher">The Dispatcher that takes an Event and dispatches it to a handler.</param>
-/// <param name="scheduler">The Scheduler that stores and schedules the Events.</param>
-/// <param name="runUntilStop">A Time that indicates when the simulation should stop.</param>
+/// <remarks>
+/// Main constructor (full control).
+/// </remarks>
 public class Simulation(
     EventDispatcher dispatcher,
     EventScheduler scheduler,
-    Time runUntilStop)
+    Time startFrom,
+    Time runUntil)
 {
+    private readonly EventDispatcher _dispatcher = dispatcher;
+    private readonly EventScheduler _scheduler = scheduler;
+    private readonly Time _startFrom = startFrom;
+    private readonly Time _runUntil = runUntil;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Simulation"/> class.
+    /// Convenience constructor (defaults runUntil to 1 day).
+    /// </summary>
+    /// <param name="dispatcher">The Dispatcher that takes an Event and dispatches it to a handler.</param>
+    /// <param name="scheduler">The Scheduler that stores and schedules the Events.</param>
+    /// <param name="runUntil">A Time that indicates when the simulation should stop.</param>
+    public Simulation(
+        EventDispatcher dispatcher,
+        EventScheduler scheduler,
+        Time runUntil)
+        : this(dispatcher, scheduler, new Time(Time.MillisecondsPerDay), runUntil)
+    {
+    }
+
     /// <summary>
     /// Runs the simulation by scheduling initial events
     /// and continuously handling the next event until
@@ -25,47 +46,47 @@ public class Simulation(
     /// <param name="waitWhilePausedAsync">A callback that blocks progress while the simulation is paused.</param>
     /// <returns>A task representing the asynchronous simulation run.</returns>
     public async Task Run(
-    CancellationToken cancelToken = default,
-    Func<Task>? waitWhilePausedAsync = null)
+        CancellationToken cancelToken = default,
+        Func<Task>? waitWhilePausedAsync = null)
+    {
+        Log.Info(0, 0, "Simulation started.");
+        Console.WriteLine("Starting Simulation");
+
+        _scheduler.ScheduleEvent(new SpawnEVS(_startFrom));
+        _scheduler.ScheduleEvent(new SnapshotEvent(_runUntil));
+
+        try
         {
-            Log.Info(0, 0, "Simulation started.");
-            Console.WriteLine("Starting Simulation");
-
-            scheduler.ScheduleEvent(new SpawnEVS(0));
-            scheduler.ScheduleEvent(new SnapshotEvent(0));
-
-            try
+            while (true)
             {
-                while (true)
+                cancelToken.ThrowIfCancellationRequested();
+
+                if (waitWhilePausedAsync != null)
+                    await waitWhilePausedAsync();
+
+                var shouldContinue = await HandleNextEvent(cancelToken);
+                if (!shouldContinue)
                 {
-                    cancelToken.ThrowIfCancellationRequested();
-
-                    if (waitWhilePausedAsync != null)
-                        await waitWhilePausedAsync();
-
-                    var shouldContinue = await HandleNextEvent(cancelToken);
-                    if (!shouldContinue)
-                    {
-                        Log.Info(0, 0, "Simulation finished.");
-                        return;
-                    }
+                    Log.Info(0, 0, "Simulation finished.");
+                    return;
                 }
             }
-            catch (OperationCanceledException)
-            {
-                Log.Info(0, 0, "Simulation stopped.");
-                Console.WriteLine("Simulation stopped.");
-            }
-            catch (Exception ex)
-            {
-                Log.Error(0, 0, ex);
-                Console.WriteLine($"Simulation crashed: {ex}");
-            }
-            finally
-            {
-                await Serilog.Log.CloseAndFlushAsync();
-            }
         }
+        catch (OperationCanceledException)
+        {
+            Log.Info(0, 0, "Simulation stopped.");
+            Console.WriteLine("Simulation stopped.");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(0, 0, ex);
+            Console.WriteLine($"Simulation crashed: {ex}");
+        }
+        finally
+        {
+            await Serilog.Log.CloseAndFlushAsync();
+        }
+    }
 
     /// <summary>
     /// Handles the next event in the scheduler.
@@ -73,17 +94,17 @@ public class Simulation(
     private async Task<bool> HandleNextEvent(CancellationToken cancelToken)
     {
         cancelToken.ThrowIfCancellationRequested();
-        var nextEvent = scheduler.GetNextEvent();
+        var nextEvent = _scheduler.GetNextEvent();
 
         if (nextEvent != null)
         {
-            if (nextEvent.Time > runUntilStop)
+            if (nextEvent.Time > _runUntil)
             {
                 Console.WriteLine("Reached end of simulation time.");
                 return false;
             }
 
-            await dispatcher.Dispatch(nextEvent);
+            await _dispatcher.Dispatch(nextEvent);
             return true;
         }
         else

--- a/Engine/Simulation.cs
+++ b/Engine/Simulation.cs
@@ -53,7 +53,7 @@ public class Simulation(
         Console.WriteLine("Starting Simulation");
 
         _scheduler.ScheduleEvent(new SpawnEVS(_startFrom));
-        _scheduler.ScheduleEvent(new SnapshotEvent(_runUntil));
+        _scheduler.ScheduleEvent(new SnapshotEvent(_startFrom));
 
         try
         {


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #None but its on the tavle.

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
I simply set the initial events from the configured startTime.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->
Its simple really no reason to test.

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [] All new and modified code has been tested (explain in Notes if not tested)  
- [X] Self-review completed  
