### PR TITLE
Reschedule FindCandidates if SoC >= 70%

### DIFF
--- a/Core/Vehicles/EV.cs
+++ b/Core/Vehicles/EV.cs
@@ -223,7 +223,7 @@ public struct EV(Battery battery, Preferences preferences, Journey journey, usho
     /// </summary>
     /// <param name="currentTime">The current simulation time.</param>
     /// <returns>The Time the next FindCandidateStation Event should occur.</returns>
-    public readonly Time TimeToNextFindCandidateCheck(Time currentTime) => Math.Min(Journey.TimeToReachHalfToNextStop(), TimeUntilHalfOfBattery(currentTime));
+    public readonly Time TimeAtNextFindCandidateCheck(Time currentTime) => Math.Min(Journey.TimeToReachHalfToNextStop(), TimeUntilHalfOfBattery(currentTime));
 
     private readonly Time TimeUntilHalfOfBattery(Time currentTime)
     {

--- a/Engine/Events/FindCandidateStationsHandler.cs
+++ b/Engine/Events/FindCandidateStationsHandler.cs
@@ -40,6 +40,14 @@ public class FindCandidateStationsHandler(
         ref var ev = ref evStore.Get(e.EVId);
         ev.Advance(e.Time);
 
+        if (ev.Battery.StateOfCharge >= 0.7f)
+        {
+            var nextCheckTime = ev.TimeAtNextFindCandidateCheck(e.Time);
+            Log.Info(e.EVId, e.Time, $"EV {e.EVId} has more than 70% SoC at find candidate stations. Rescheduling next check at {nextCheckTime}.");
+            eventScheduler.ScheduleEvent(new FindCandidateStations(e.EVId, nextCheckTime));
+            return;
+        }
+
         Log.Verbose(e.EVId, e.Time, $"Handling FindCandidateStations for EV {e.EVId} at time {e.Time}. Current EV data: {ev}. SoC: {ev.Battery.StateOfCharge}, Next stop in {ev.Journey.Current.DurationToNextStop}ms.)", ("Journey", ev.Journey));
         if (candidateStations.Count == 0)
         {
@@ -65,7 +73,7 @@ public class FindCandidateStationsHandler(
             return;
         }
 
-        eventScheduler.ScheduleEvent(new FindCandidateStations(e.EVId, ev.TimeToNextFindCandidateCheck(e.Time)));
+        eventScheduler.ScheduleEvent(new FindCandidateStations(e.EVId, ev.TimeAtNextFindCandidateCheck(e.Time)));
     }
 
     private void HandleNoCandidates(FindCandidateStations e, ref EV ev)

--- a/Engine/Services/StationService.cs
+++ b/Engine/Services/StationService.cs
@@ -168,7 +168,7 @@ public class StationService : IStationService
         else
         {
             Log.Info(e.EVId, e.Time, $"EV {e.EVId} has completed its charging but cannot continue to its destination with SoC {ev.Battery.StateOfCharge}. Scheduling search for candidate stations.");
-            _scheduler.ScheduleEvent(new FindCandidateStations(e.EVId, ev.TimeToNextFindCandidateCheck(e.Time)));
+            _scheduler.ScheduleEvent(new FindCandidateStations(e.EVId, ev.TimeAtNextFindCandidateCheck(e.Time)));
         }
 
         if (!_evReservations.TryGetValue(e.EVId, out var stationId))

--- a/Tests/Core.test/Vehicles.test/EVTests.cs
+++ b/Tests/Core.test/Vehicles.test/EVTests.cs
@@ -229,7 +229,7 @@ public class EVTests
             efficiency: 150,
             distanceMeter: 100000f);
 
-        var result = ev.TimeToNextFindCandidateCheck(0);
+        var result = ev.TimeAtNextFindCandidateCheck(0);
 
         Assert.Equal(1800u, result.TotalSeconds);
     }
@@ -246,7 +246,7 @@ public class EVTests
             efficiency: 150,
             distanceMeter: 100000f);
 
-        var result = ev.TimeToNextFindCandidateCheck(0);
+        var result = ev.TimeAtNextFindCandidateCheck(0);
 
         Assert.Equal(720u, result.TotalSeconds);
     }
@@ -263,7 +263,7 @@ public class EVTests
             efficiency: 150,
             distanceMeter: 100000f);
 
-        var result = ev.TimeToNextFindCandidateCheck(0);
+        var result = ev.TimeAtNextFindCandidateCheck(0);
 
         Assert.Equal(1800u, result.TotalSeconds);
     }
@@ -280,7 +280,7 @@ public class EVTests
             efficiency: 150,
             distanceMeter: 100000f);
 
-        var result = ev.TimeToNextFindCandidateCheck(1000);
+        var result = ev.TimeAtNextFindCandidateCheck(1000);
 
         Assert.Equal(721u, result.TotalSeconds);
     }


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #None it is on the tavle

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
Added a check in findCandidateStationHandler to stop EV's with > 70% SoC from finding stations.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->
No testing, it is literally just an if statement.

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [ ] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
