### PR TITLE
Added drive directly to metrics

### DIFF
--- a/Engine/Metrics/Events/ArrivalAtDestinationMetric.cs
+++ b/Engine/Metrics/Events/ArrivalAtDestinationMetric.cs
@@ -24,6 +24,11 @@ public readonly struct ArrivalAtDestinationMetric
     required public int PathDeviation { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether an EV drives directly to its destination or goes charging.
+    /// </summary>
+    required public bool DriveDirectlyToDestination { get; init; }
+
+    /// <summary>
     /// Gets the difference between actual and expected arrival time.
     /// </summary>
     public int DeltaArrivalTime => (int)ActualArrivalTime - (int)ExpectedArrivalTime;
@@ -50,6 +55,7 @@ public readonly struct ArrivalAtDestinationMetric
             ActualArrivalTime = actualArrivalTime,
             PathDeviation = ev.Journey.Current.PathDeviation,
             MissedDeadline = actualArrivalTime > expectedArrivalTime,
+            DriveDirectlyToDestination = ev.DriveDirectlyToDestination,
         };
     }
 }


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
Adds the DriveDirectlyToDestination flag to the arrival metrics, so that they can be considered on the python evanalysis side of the project.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [ ] All new and modified code has been tested (explain in Notes if not tested)  
- [ ] Self-review completed  
