### PR TITLE
use table duration/distance in EVDetourPlanner for consistency

### DIFF
--- a/Core/Vehicles/EV.cs
+++ b/Core/Vehicles/EV.cs
@@ -286,6 +286,10 @@ public struct EV(Battery battery, Preferences preferences, Journey journey, usho
     {
         var socAtStation = (Battery.CurrentChargeKWh - EnergyForDistanceKWh(distToStation / 1000)) / Battery.MaxCapacityKWh;
         var expectChargeTarget = PreCalculatedTargetSoC(distToDestination / 1000) * chargeBufferPercent;
-        return socAtStation > expectChargeTarget;
+
+        var socAtDestination = socAtStation - EnergyForDistanceKWh(distToDestination / 1000) / Battery.MaxCapacityKWh;
+        var canReachDestWithMinCharge = socAtDestination >= Preferences.MinAcceptableCharge;
+
+        return socAtStation > expectChargeTarget && canReachDestWithMinCharge;
     }
 }

--- a/Engine/Events/FindCandidateStationsHandler.cs
+++ b/Engine/Events/FindCandidateStationsHandler.cs
@@ -123,6 +123,14 @@ public class FindCandidateStationsHandler(
             return;
         }
 
-        throw Log.Error(e.EVId, e.Time, new InvalidOperationException($"No candidate stations available for EV {e.EVId} at {e.Time}."));
+        var waypointText = string.Join(" -> ", ev.Journey.Current.Waypoints.Select(p => $"({p.Longitude:F6}, {p.Latitude:F6})"));
+        Log.Warn(e.EVId, e.Time, $"No candidate stations found for EV {e.EVId} at time {e.Time}, and no existing reservation.", ("EV", ev), ("Journey", ev.Journey), ("EV SoC", ev.Battery.StateOfCharge), ("Waypoints", waypointText));
+        throw Log.Error(
+            e.EVId,
+            e.Time,
+            new InvalidOperationException($"No candidate stations available for EV {e.EVId} at {e.Time}. EV data: {ev}, Journey: {ev.Journey}, Waypoints: {waypointText}"),
+            ("EV", ev),
+            ("Journey", ev.Journey),
+            ("Waypoints", waypointText));
     }
 }

--- a/Engine/Events/FindCandidateStationsHandler.cs
+++ b/Engine/Events/FindCandidateStationsHandler.cs
@@ -56,17 +56,33 @@ public class FindCandidateStationsHandler(
         }
 
         var bestStation = costFunction.Compute(ref ev, candidateStations, e.Time) ?? throw Log.Error(e.EVId, e.Time, new SkillissueException("Cost function did not return a station, but should never get this far."));
+        var candidate = candidateStations[bestStation.Id];
 
         if (stationService.GetReservationStationId(e.EVId) != bestStation.Id)
-            evDetourPlanner.Update(ref ev, bestStation, e.Time);
+        {
+            evDetourPlanner.Update(
+                ref ev,
+                bestStation,
+                e.Time,
+                candidate.DurToStation + candidate.DurToDest,
+                candidate.DistToStationMeters + candidate.DistStationToDestMeters);
+        }
 
         var remaining = ev.Journey.Current.DurationToNextStop;
         var etaAtStation = e.Time + remaining;
-        var candidate = candidateStations[bestStation.Id];
         var targetSoC = candidate.DistStationToDestMeters > 0f
             ? ev.PreCalculatedTargetSoC(candidate.DistStationToDestMeters / 1000f)
             : ev.CalcDesiredSoC(etaAtStation);
         var socAtArrival = ev.EstimateSoCAtNextStop();
+
+        if (socAtArrival >= targetSoC)
+        {
+            throw Log.Error(e.EVId, e.Time, new InvalidOperationException(
+                $"Invalid reservation for EV {e.EVId}: estimated SoC at arrival ({socAtArrival}) is >= target SoC ({targetSoC})."),
+                ("Candidate", candidate),
+                ("BestStationId", bestStation.Id));
+        }
+
         stationService.HandleReservation(new Reservation(e.EVId, etaAtStation, socAtArrival, targetSoC), bestStation.Id);
 
         if (remaining <= Time.MillisecondsPerMinute * 10)

--- a/Engine/Events/Middleware/FindCandidateStationService.cs
+++ b/Engine/Events/Middleware/FindCandidateStationService.cs
@@ -14,7 +14,8 @@ using Core.Helper;
 /// <param name="DurToStation">Duration from the EV position to the candidate station.</param>
 /// <param name="DurToDest">Duration from the candidate station to the destination.</param>
 /// <param name="DistStationToDestMeters">Distance from the candidate station to the destination in meters.</param>
-public struct DurToStationAndDest(float DurToStation, float DurToDest, float DistStationToDestMeters = 0f)
+/// <param name="DistToStationMeters">Distance from the EV position to the candidate station in meters.</param>
+public struct DurToStationAndDest(float DurToStation, float DurToDest, float DistStationToDestMeters, float DistToStationMeters)
 {
     /// <summary>Duration from the EV position to the candidate station.</summary>
     public float DurToStation = DurToStation;
@@ -24,6 +25,9 @@ public struct DurToStationAndDest(float DurToStation, float DurToDest, float Dis
 
     /// <summary>Distance from the candidate station to the destination in meters.</summary>
     public float DistStationToDestMeters = DistStationToDestMeters;
+
+    /// <summary>Distance from the EV position to the candidate station in meters.</summary>
+    public float DistToStationMeters = DistToStationMeters;
 }
 
 /// <summary>Service responsible for pre-computing the candidate stations for an EV and caching the results for later retrieval.</summary>
@@ -107,7 +111,7 @@ public class FindCandidateStationService(
                 if (ev.CheckIfTargetSoCIsLowerThanCurrentSoC(toStation.Item2, toDestination.Item2, settings.ChargeBufferPercent))
                     continue;
 
-                refinedCandidateDurations[stationId] = new DurToStationAndDest(toStation.Item1, toDestination.Item1, toDestination.Item2);
+                refinedCandidateDurations[stationId] = new DurToStationAndDest(toStation.Item1, toDestination.Item1, toDestination.Item2, toStation.Item2);
             }
 
             if (refinedCandidateDurations.Count == 0 && stationService.GetReservationStationId(e.EVId) is ushort && ev.DistanceOnCurrentChargeKm() > pathDeviationMultiplied)

--- a/Engine/Routing/EVDetourPlanner.cs
+++ b/Engine/Routing/EVDetourPlanner.cs
@@ -4,6 +4,7 @@ using Core.Shared;
 using Core.Charging;
 using Core.Vehicles;
 using Engine.Utils;
+using Core.Helper;
 
 /// <summary>
 /// Calculates detour deviations by querying OSRM routes.
@@ -19,17 +20,24 @@ public class EVDetourPlanner(IDestinationRouter router) : IEVDetourPlanner
     /// <param name="ev">The EV to reroute.</param>
     /// <param name="station">The station the EV should reroute through.</param>
     /// <param name="currentTime">Used to determine the EV's current position in the journey.</param>
-    public void Update(ref EV ev, Station station, Time currentTime)
+    /// <param name="tableDuration">Total detour duration from current position to destination via station.</param>
+    /// <param name="tableDistance">Total detour distance from current position to destination via station.</param>
+    public void Update(ref EV ev, Station station, Time currentTime, float tableDuration, float tableDistance)
     {
         var currentPos = ev.Advance(currentTime);
         var destination = ev.Journey.Current.Waypoints.Last();
-
         var res = _router.QueryDestinationWithStop(
-            currentPos.Longitude, currentPos.Latitude, station.Position.Longitude, station.Position.Latitude, destination.Longitude, destination.Latitude, station.Id);
+            currentPos.Longitude, currentPos.Latitude,
+            station.Position.Longitude, station.Position.Latitude,
+            destination.Longitude, destination.Latitude,
+            station.Id);
+
+        if (res.Duration < 0 || string.IsNullOrEmpty(res.Polyline))
+            throw Log.Error(0, 0, new InvalidOperationException($"Route query failed for station {station.Id}."), ("StationId", station.Id));
 
         var detourPath = Polyline6ToPoints.DecodePolyline(res.Polyline);
         var newWaypoints = new List<Position>([currentPos, .. detourPath]);
-        var roundedDuration = (uint)Math.Ceiling(res.Duration);
-        ev.Journey.UpdateRoute(newWaypoints, station.Position, currentTime, (Time)roundedDuration, res.Distance / 1000);
+        var roundedDuration = (uint)Math.Ceiling((double)tableDuration);
+        ev.Journey.UpdateRoute(newWaypoints, station.Position, currentTime, (Time)roundedDuration, tableDistance / 1000f);
     }
 }

--- a/Engine/Routing/EVDetourPlanner.cs
+++ b/Engine/Routing/EVDetourPlanner.cs
@@ -33,7 +33,7 @@ public class EVDetourPlanner(IDestinationRouter router) : IEVDetourPlanner
             station.Id);
 
         if (res.Duration < 0 || string.IsNullOrEmpty(res.Polyline))
-            throw Log.Error(0, 0, new InvalidOperationException($"Route query failed for station {station.Id}."), ("StationId", station.Id));
+            throw Log.Error(0, currentTime, new InvalidOperationException($"Route query failed for station {station.Id}."), ("StationId", station.Id));
 
         var detourPath = Polyline6ToPoints.DecodePolyline(res.Polyline);
         var newWaypoints = new List<Position>([currentPos, .. detourPath]);

--- a/Engine/Routing/IEVDetourPlanner.cs
+++ b/Engine/Routing/IEVDetourPlanner.cs
@@ -16,5 +16,7 @@ public interface IEVDetourPlanner
     /// <param name="ev">The EV to reroute.</param>
     /// <param name="station">The station the EV should reroute through.</param>
     /// <param name="currentTime">Used to determine the EV's current position in the journey.</param>
-    void Update(ref EV ev, Station station, Time currentTime);
+    /// <param name="tableDuration">Total detour duration from current position to destination via station.</param>
+    /// <param name="tableDistance">Total detour distance from current position to destination via station.</param>
+    void Update(ref EV ev, Station station, Time currentTime, float tableDuration, float tableDistance);
 }

--- a/Tests/Engine.test/Cost/ComputeCostTest.cs
+++ b/Tests/Engine.test/Cost/ComputeCostTest.cs
@@ -1,6 +1,6 @@
-using Engine.Events.Middleware;
 namespace Engine.test.Cost;
 
+using Engine.Events.Middleware;
 using Core.Charging;
 using Core.Routing;
 using Core.Shared;
@@ -34,8 +34,8 @@ public class ComputeCostTest
 
         var stationDurations = new Dictionary<ushort, DurToStationAndDest>
         {
-            { 1, new DurToStationAndDest(500000f, 500000f) }, // Deviation = 0
-            { 2, new DurToStationAndDest(600000f, 600000f) }, // Deviation = 100
+            { 1, new DurToStationAndDest(500000f, 500000f, 0f, 0f) }, // Deviation = 0
+            { 2, new DurToStationAndDest(600000f, 600000f, 100f, 100f) }, // Deviation = 100
         };
 
         var bestStation = computeCost.Compute(ref ev, stationDurations, _time);
@@ -64,8 +64,8 @@ public class ComputeCostTest
 
         var stationDurations = new Dictionary<ushort, DurToStationAndDest>
         {
-            { 1, new DurToStationAndDest(500000f, 500000f) },
-            { 2, new DurToStationAndDest(500000f, 500000f) },
+            { 1, new DurToStationAndDest(500000f, 500000f, 0f, 0f) },
+            { 2, new DurToStationAndDest(500000f, 500000f, 0f, 0f) },
         };
 
         var bestStation = computeCost.Compute(ref ev, stationDurations, _time);
@@ -95,8 +95,8 @@ public class ComputeCostTest
 
         var stationDurations = new Dictionary<ushort, DurToStationAndDest>
             {
-                { 1, new DurToStationAndDest(500000f, 500000f) },
-                { 2, new DurToStationAndDest(500000f, 500000f) },
+                { 1, new DurToStationAndDest(500000f, 500000f, 0f, 0f) },
+                { 2, new DurToStationAndDest(500000f, 500000f, 0f, 0f) },
             };
 
         var bestStation = computeCost.Compute(ref ev, stationDurations, _time);
@@ -152,7 +152,7 @@ public class ComputeCostTest
             duration: new Time(900000),
             newDistanceKm: 150);
 
-        var stationDurations = new Dictionary<ushort, DurToStationAndDest> { { 1, new DurToStationAndDest(600000f, 600000f) }, { 2, new DurToStationAndDest(650000f, 650000f) } };
+        var stationDurations = new Dictionary<ushort, DurToStationAndDest> { { 1, new DurToStationAndDest(600000f, 600000f, 0f, 0f) }, { 2, new DurToStationAndDest(650000f, 650000f, 50f, 50f) } };
         var bestStation = computeCost.Compute(ref ev, stationDurations, new Time(250000));
 
         Assert.Equal(1, bestStation.Id);
@@ -203,7 +203,7 @@ public class ComputeCostTest
         // At time 600, choose between two more charging stations
         // Station 20: 600 second detour = 0 deviation (perfect match)
         // Station 30: 650 second detour = ~0.83 min deviation
-        var stationDurations = new Dictionary<ushort, DurToStationAndDest> { { 20, new DurToStationAndDest(600000f, 600000f) }, { 30, new DurToStationAndDest(650000f, 650000f) } };
+        var stationDurations = new Dictionary<ushort, DurToStationAndDest> { { 20, new DurToStationAndDest(600000f, 600000f, 0f, 0f) }, { 30, new DurToStationAndDest(650000f, 650000f, 50f, 50f) } };
         var bestStation = computeCost.Compute(ref ev, stationDurations, new Time(600000));
 
         Assert.Equal(20, bestStation.Id);

--- a/Tests/Engine.test/Events/FindCandidateStationsHandlerTest.cs
+++ b/Tests/Engine.test/Events/FindCandidateStationsHandlerTest.cs
@@ -1,6 +1,6 @@
-using Engine.Events.Middleware;
 namespace Engine.Test.Events;
 
+using Engine.Events.Middleware;
 using Core.Shared;
 using Engine.Cost;
 using Engine.Events;
@@ -59,13 +59,13 @@ public class FindCandidateStationsHandlerTest
     public async Task Handle_NoReservationButCandidates_SchedulesNewFindcandidate()
     {
         var waypoints = new List<Position> { new(58, 9), new(58.5, 9.5) };
-        var ev = CoreTestData.EV(waypoints);
+        var ev = CoreTestData.EV(waypoints, originalDuration: 10000000);
         _evStore.TryAllocate((_, ref e) => { e = ev; }, out var index1);
         var e = new FindCandidateStations(index1, 0);
 
         var stubService = (StubFindCandidateStationService)_findCandidateStationService;
         var stationId = EngineTestData.AllStations.Keys.First();
-        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { stationId, new DurToStationAndDest(100f, 100f) } });
+        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { stationId, new DurToStationAndDest(350000f, 350000f, 300_000f, 500f) } });
 
         await _handler.Handle(e);
 
@@ -107,12 +107,12 @@ public class FindCandidateStationsHandlerTest
         var stationId = EngineTestData.AllStations.Keys.First();
         var ev = CoreTestData.EV(waypoints, originalDuration: 10000000, departureTime: 0);
         _evStore.TryAllocate((_, ref e) => { e = ev; }, out var index1);
-        _stationService.HandleReservation(new Reservation(index1, 0, 0.2, 0.8), stationId);
+        _stationService.HandleReservation(new Reservation(index1, 0, 0.1, 0.5), stationId);
 
         var e = new FindCandidateStations(index1, 0);
 
         var stubService = (StubFindCandidateStationService)_findCandidateStationService;
-        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { stationId, new DurToStationAndDest(1000f, 1000f) } });
+        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { stationId, new DurToStationAndDest(1000f, 1000f, 300_000f, 500f) } });
 
         await _handler.Handle(e);
 
@@ -129,16 +129,16 @@ public class FindCandidateStationsHandlerTest
     public async Task Handle_ExistingReservationWorseThanCandidates_CancelEventAndScheduleFindcandidate()
     {
         var waypoints = new List<Position> { new(58, 9), new(58.5, 9.5) };
-        var ev = CoreTestData.EV(waypoints);
+        var ev = CoreTestData.EV(waypoints, originalDuration: 10000000);
         var existingStationId = EngineTestData.AllStations.Keys.First();
         _evStore.TryAllocate((_, ref e) => { e = ev; }, out var index1);
-        _stationService.HandleReservation(new Reservation(index1, 0, 0.2, 0.8), existingStationId);
+        _stationService.HandleReservation(new Reservation(index1, 0, 0.1, 0.5), existingStationId);
 
         var e = new FindCandidateStations(index1, 0);
 
         var stubService = (StubFindCandidateStationService)_findCandidateStationService;
         var betterStationId = EngineTestData.AllStations.Keys.Skip(1).First();
-        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { betterStationId, new DurToStationAndDest(50f, 50f) } });
+        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { betterStationId, new DurToStationAndDest(350000f, 350000f, 300_000f, 500f) } });
 
         await _handler.Handle(e);
         var eventAfterCancel = _eventScheduler.GetNextEvent();
@@ -158,14 +158,14 @@ public class FindCandidateStationsHandlerTest
         var ev = CoreTestData.EV(waypoints, originalDuration: 500000, departureTime: 0);
 
         _evStore.TryAllocate((_, ref e) => { e = ev; }, out var index1);
-        _stationService.HandleReservation(new Reservation(index1, 0, 0.2, 0.8), stationId);
+        _stationService.HandleReservation(new Reservation(index1, 0, 0.1, 0.5), stationId);
 
         ref var storedEv = ref _evStore.Get(index1);
         storedEv.Advance(1);
         var e = new FindCandidateStations(index1, 1);
 
         var stubService = (StubFindCandidateStationService)_findCandidateStationService;
-        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { stationId, new DurToStationAndDest(1f, 1f) } });
+        stubService.SetCandidates(index1, new Dictionary<ushort, DurToStationAndDest> { { stationId, new DurToStationAndDest(1f, 1f, 300_000f, 500f) } });
 
         await _handler.Handle(e);
 

--- a/Tests/Engine.test/Events/Middleware/FindcandidateStationServiceTest.cs
+++ b/Tests/Engine.test/Events/Middleware/FindcandidateStationServiceTest.cs
@@ -71,9 +71,9 @@ namespace Engine.Test.Events.Middleware
 
             var expected = new Dictionary<ushort, DurToStationAndDest>
             {
-                { 0, new DurToStationAndDest(10.0f, 0f, 300_000f) },
-                { 2, new DurToStationAndDest(25f, 0f, 300_000f) },
-                { 4, new DurToStationAndDest(180f, 0f, 300_000f) },
+                { 0, new DurToStationAndDest(10.0f, 0f, 300_000f, 500f) },
+                { 2, new DurToStationAndDest(25f, 0f, 300_000f, 130f) },
+                { 4, new DurToStationAndDest(180f, 0f, 300_000f, 300f) },
             };
             Assert.Equal(expected, candidates);
         }

--- a/Tests/Engine.test/Routing/ApplyNewPathTests.cs
+++ b/Tests/Engine.test/Routing/ApplyNewPathTests.cs
@@ -39,7 +39,7 @@ public class ApplyNewPathToEVTests()
         var applyNewPath = new EVDetourPlanner(fakeRouter);
         var currentTime = new Time(10);
 
-        applyNewPath.Update(ref ev, station, currentTime);
+        applyNewPath.Update(ref ev, station, currentTime, tableDuration: fakeRouter.ReturnedDuration, tableDistance: 0);
 
         Assert.Equal(150.0f, (uint)ev.Journey.Current.Duration);
         Assert.Equal(10U, (uint)ev.Journey.Current.Departure);
@@ -77,12 +77,12 @@ public class ApplyNewPathToEVTests()
         var station = CoreTestData.Station(1, new Position(5, 5));
 
         Assert.Throws<InvalidOperationException>(() =>
-            applyNewPath.Update(ref ev, station, new Time(99000)));
+            applyNewPath.Update(ref ev, station, new Time(99000), fakeRouter.ReturnedDuration, 0));
 
         const uint outsideApproxTolerance = 310000; // 5 minutes and 10 seconds, which is outside the 5 minute tolerance
 
         Assert.Throws<ArgumentException>(() =>
-            applyNewPath.Update(ref ev, station, new Time(150000 + outsideApproxTolerance)));
+            applyNewPath.Update(ref ev, station, new Time(150000 + outsideApproxTolerance), fakeRouter.ReturnedDuration, 0));
     }
 
     public class FakeDestinationRouter : IDestinationRouter


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #

## Description of Implementation (optional)
Updated EVDetourPlanner to use the precomputed table values for route updates
while still using QueryDestinationWithStop solely for the polyline.

## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
