### PR TITLE
Fix SoC at 0% throw

### DIFF
--- a/Core/Routing/Journey.cs
+++ b/Core/Routing/Journey.cs
@@ -55,12 +55,20 @@ public record CurrentJourney(
 public class Journey(Time departure, Time duration, float distanceMeters, List<Position> waypoints)
 {
     /// <summary>Gets the original baseline of the journey.</summary>
-    public OriginalJourney Original { get; } = new(departure, duration > 0 ? duration : throw Log.Error(0, 0, new ArgumentOutOfRangeException("Duration can't be zero")), distanceMeters / 1000);
+    public OriginalJourney Original { get; } = new(
+        departure,
+        duration > 0 ? duration : throw Log.Error(0, 0, new ArgumentOutOfRangeException("Duration can't be zero")),
+        distanceMeters / 1000);
 
     /// <summary>Gets the live state of the journey.</summary>
-    public CurrentJourney Current { get; private set; } = new(
-        departure, duration, distanceMeters / 1000,
-        waypoints, waypoints[^1], PathDeviation: 0, DurationToNextStop: duration);
+    public CurrentJourney Current { get; private set; } = new CurrentJourney(
+            Departure: departure,
+            Duration: duration,
+            DistanceKm: distanceMeters / 1000,
+            Waypoints: waypoints,
+            NextStop: waypoints[^1],
+            PathDeviation: 0,
+            DurationToNextStop: duration);
 
     /// <summary>
     /// Calculates the remaining time on the current route,
@@ -105,11 +113,12 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
         CheckTime(currentTime, checkBeforeDeparture: true, checkAfterCompletion: true, checkAfterEtaToNextStop: true);
         var (currentJourney, currentPos) = DeriveRouteSnapshot(currentTime);
         Current = currentJourney;
+        ValidateCurrentJourney();
         return currentPos;
     }
 
     /// <summary>
-    /// Updates the route of the journey and calculates the new path deviation based on the new estimated time of arrival (ETA) compared to the old ETA.
+    /// Updates the route of the journey and calculates the new path deviation based on the new estimated time of arrival compared to the old ETA.
     /// </summary>
     /// <param name="waypoints">The new waypoints of the journey.</param>
     /// <param name="nextStop">The next stop/position of <paramref name="waypoints"/>.</param>
@@ -119,9 +128,22 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     public void UpdateRoute(List<Position> waypoints, Position nextStop, Time departure, Time duration, float newDistanceKm)
     {
         CheckTime(departure, checkBeforeDeparture: true, checkAfterCompletion: false, checkAfterEtaToNextStop: false);
+        ValidateWaypoints(waypoints);
+
+        var resolvedNextStop = ResolveNextStop(waypoints, nextStop);
         var deviation = Current.PathDeviation + (departure + duration) - Current.Eta;
-        var durationToNextStop = DurationToNextStop(duration, waypoints, nextStop);
-        Current = new CurrentJourney(departure, duration, newDistanceKm, waypoints, nextStop, (int)deviation, durationToNextStop);
+        var durationToNextStop = DurationToNextStop(duration, waypoints, resolvedNextStop);
+
+        Current = new CurrentJourney(
+            departure,
+            duration,
+            newDistanceKm,
+            waypoints,
+            resolvedNextStop,
+            (int)deviation,
+            durationToNextStop);
+
+        ValidateCurrentJourney();
     }
 
     /// <summary>
@@ -130,22 +152,28 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     /// <param name="timeAtStation">The amount of time spent at a station.</param>
     public void UpdateRouteToDestination(Time timeAtStation)
     {
+        ValidateCurrentJourney();
+
+        var destination = Current.Waypoints[^1];
         var newDeparture = Current.Departure + timeAtStation + Current.DurationToNextStop;
+        var durationToDestination = DurationToNextStop(Current.Duration, Current.Waypoints, destination);
 
         Current = new CurrentJourney(
             Departure: newDeparture,
             Duration: Current.Duration,
             DistanceKm: Current.DistanceKm,
             Waypoints: Current.Waypoints,
-            NextStop: Current.Waypoints[^1],
+            NextStop: destination,
             PathDeviation: Current.PathDeviation,
-            DurationToNextStop: DurationToNextStop(Current.Duration, Current.Waypoints, Current.Waypoints[^1]));
+            DurationToNextStop: durationToDestination);
+
+        ValidateCurrentJourney();
     }
 
     /// <summary>
     /// Finds the time it would take to drive a given distance based on the original average speed of the journey.
     /// </summary>
-    /// <param name="distance">The distance a EV has to drive.</param>
+    /// <param name="distance">The distance an EV has to drive.</param>
     /// <returns>Returns how long it takes to drive a distance in seconds.</returns>
     public Time TimeToDriveDistance(float distance)
     {
@@ -162,13 +190,18 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     /// <returns>Time to reach halfway to NextStop.</returns>
     public Time TimeToReachHalfToNextStop() => Current.Departure + (Current.DurationToNextStop / 2);
 
+    /// <summary>
+    /// Determines if the EV can reach through the given waypoints within its battery capacity.
+    /// </summary>
+    /// <param name="waypoints">The waypoints to check.</param>
+    /// <param name="distanceEvCanDrive">The maximum distance the EV can drive on a single charge.</param>
+    /// <returns>True if the EV can reach through the waypoints, false otherwise.</returns>
     public bool CanReachThroughWaypoints(List<Position> waypoints, double distanceEvCanDrive)
     {
-        var segments = Enumerable.Range(0, waypoints.Count - 1)
-            .Select(i =>
+        ValidateWaypoints(waypoints);
 
-                    GeoMath.EquirectangularDistance(waypoints[i], waypoints[i + 1])
-                )
+        var segments = Enumerable.Range(0, waypoints.Count - 1)
+            .Select(i => GeoMath.EquirectangularDistance(waypoints[i], waypoints[i + 1]))
             .ToList();
         var distanceCovered = 0.0;
 
@@ -181,6 +214,7 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
 
             distanceCovered += length;
         }
+
         return true;
     }
 
@@ -201,14 +235,25 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     /// <returns>A new route snapshot together with the interpolated current position.</returns>
     private (CurrentJourney Journey, Position CurrentPosition) DeriveRouteSnapshot(Time currentTime)
     {
+        ValidateCurrentJourney();
+
         var percentageCompleted = PercentageCompleted(currentTime);
         var ratio = 1 - percentageCompleted;
         var duration = (uint)Math.Ceiling(ratio * Current.Duration);
         var newDistanceKm = ratio * Current.DistanceKm;
         var waypoints = DeriveNewWaypoints(currentTime);
-        var durationToNextStop = DurationToNextStop(duration, waypoints, Current.NextStop);
+        var resolvedNextStop = ResolveNextStopAfterDerivation(waypoints);
+        var durationToNextStop = DurationToNextStop(duration, waypoints, resolvedNextStop);
 
-        var currentJourney = new CurrentJourney(currentTime, duration, newDistanceKm, waypoints, Current.NextStop, Current.PathDeviation, durationToNextStop);
+        var currentJourney = new CurrentJourney(
+            currentTime,
+            duration,
+            newDistanceKm,
+            waypoints,
+            resolvedNextStop,
+            Current.PathDeviation,
+            durationToNextStop);
+
         return (currentJourney, waypoints[0]);
     }
 
@@ -218,8 +263,7 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     /// <param name="currentTime">Simulation time to derive from.</param>
     /// <returns>
     /// A list that starts with the interpolated current position, followed by the remaining waypoints
-    /// from the interpolation segment boundary. The configured <see cref="CurrentJourney.NextStop"/>
-    /// is preserved as a hard boundary for derivation, even if the returned suffix contains waypoints beyond it.
+    /// from the interpolation segment boundary.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="currentTime"/> is outside valid bounds or if derivation would move
@@ -228,6 +272,7 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     private List<Position> DeriveNewWaypoints(Time currentTime)
     {
         CheckTime(currentTime, checkBeforeDeparture: true, checkAfterCompletion: true, checkAfterEtaToNextStop: true);
+        ValidateCurrentJourney();
 
         var percentageCompleted = PercentageCompleted(currentTime);
 
@@ -240,6 +285,9 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
                     Length: GeoMath.EquirectangularDistance(Current.Waypoints[i], Current.Waypoints[i + 1])
                 ))
             .ToList();
+
+        if (segments.Count == 0)
+            return [Current.Waypoints[0]];
 
         var totalLength = segments.Sum(s => s.Length);
         var distanceTraveled = percentageCompleted * totalLength;
@@ -255,33 +303,38 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
             }
 
             var remainingDistance = distanceTraveled - distanceCovered;
-            var ratio = remainingDistance / length;
+            var ratio = length <= 0 ? 0 : remainingDistance / length;
             var latitude = first.Latitude + (ratio * (second.Latitude - first.Latitude));
             var longitude = first.Longitude + (ratio * (second.Longitude - first.Longitude));
             var currentPos = new Position(Longitude: longitude, Latitude: latitude);
 
             var nextStopIndex = FindNextStopIndex(Current.Waypoints, Current.NextStop);
-            var nextStopExists = nextStopIndex >= 0;
-            var interpolationPassedNextStop = nextStopExists && secondIndex > nextStopIndex;
+            var interpolationPassedNextStop = secondIndex > nextStopIndex;
+
             if (interpolationPassedNextStop)
             {
                 if (currentTime != Current.EtaToNextStop)
-                    throw Log.Error(0, currentTime, new ArgumentException($"Illegal context: interpolation moved beyond next stop at currentTime={currentTime}. nextStopIndex={nextStopIndex}, segmentIndex={secondIndex}."));
+                {
+                    throw Log.Error(
+                        0,
+                        currentTime,
+                        new ArgumentException(
+                            $"Illegal context: interpolation moved beyond next stop at currentTime={currentTime}. " +
+                            $"nextStopIndex={nextStopIndex}, segmentIndex={secondIndex}, NextStop={Current.NextStop}."));
+                }
 
-                // Rounding nudged us one segment past the next stop — snap back to it.
                 var nextStopPos = Current.Waypoints[nextStopIndex];
                 var remainingWaypoints = Current.Waypoints.Skip(nextStopIndex + 1).ToList();
-                return new List<Position>([nextStopPos, .. remainingWaypoints]);
+                return [nextStopPos, .. remainingWaypoints];
             }
 
-            var suffixStartIndex = secondIndex;
-            var remainingWaypoints2 = Current.Waypoints.Skip(suffixStartIndex).ToList();
+            var remainingWaypoints2 = Current.Waypoints.Skip(secondIndex).ToList();
 
-            return new List<Position>([currentPos, .. remainingWaypoints2]);
+            return [currentPos, .. remainingWaypoints2];
         }
 
         var last = Current.Waypoints[^1];
-        return new List<Position>([last]);
+        return [last];
     }
 
     /// <summary>
@@ -294,9 +347,21 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     /// <returns>Estimated duration from route start to next stop.</returns>
     private static Time DurationToNextStop(Time totalDuration, List<Position> waypoints, Position nextStop)
     {
+        ValidateWaypoints(waypoints);
+
         var nextStopIndex = FindNextStopIndex(waypoints, nextStop);
         if (nextStopIndex < 0)
-            return totalDuration;
+        {
+            throw Log.Error(
+                0,
+                0,
+                new InvalidOperationException(
+                    $"NextStop was not found in waypoints. NextStop={nextStop}. " +
+                    $"First={waypoints[0]}, Last={waypoints[^1]}, " +
+                    $"Closest={FindClosestWaypoint(waypoints, nextStop)}, " +
+                    $"WaypointCount={waypoints.Count}."));
+        }
+
         if (nextStopIndex == 0)
             return 0;
 
@@ -309,6 +374,94 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
         return (uint)Math.Ceiling(ratio * totalDuration);
     }
 
+    private static Position ResolveNextStop(List<Position> waypoints, Position requestedNextStop)
+    {
+        ValidateWaypoints(waypoints);
+
+        if (FindNextStopIndex(waypoints, requestedNextStop) >= 0)
+            return requestedNextStop;
+
+        var closest = FindClosestWaypoint(waypoints, requestedNextStop);
+
+        throw Log.Error(
+            0,
+            0,
+            new InvalidOperationException(
+                $"Invalid route update: requested next stop is not part of the supplied route. " +
+                $"RequestedNextStop={requestedNextStop}, ClosestWaypoint={closest}, " +
+                $"First={waypoints[0]}, Last={waypoints[^1]}, WaypointCount={waypoints.Count}."));
+    }
+
+    private Position ResolveNextStopAfterDerivation(List<Position> derivedWaypoints)
+    {
+        ValidateWaypoints(derivedWaypoints);
+
+        if (FindNextStopIndex(derivedWaypoints, Current.NextStop) >= 0)
+            return Current.NextStop;
+
+        if (Current.NextStop == Current.Waypoints[^1])
+            return derivedWaypoints[^1];
+
+        var closest = FindClosestWaypoint(derivedWaypoints, Current.NextStop);
+
+        throw Log.Error(
+            0,
+            0,
+            new InvalidOperationException(
+                $"Invalid derived journey: current NextStop is no longer part of the derived route. " +
+                $"NextStop={Current.NextStop}, ClosestDerivedWaypoint={closest}, " +
+                $"First={derivedWaypoints[0]}, Last={derivedWaypoints[^1]}, WaypointCount={derivedWaypoints.Count}."));
+    }
+
+    private void ValidateCurrentJourney()
+    {
+        ValidateWaypoints(Current.Waypoints);
+
+        var nextStopIndex = FindNextStopIndex(Current.Waypoints, Current.NextStop);
+
+        if (nextStopIndex < 0)
+        {
+            throw Log.Error(
+                0,
+                0,
+                new InvalidOperationException(
+                    $"Invalid journey: NextStop is not in Waypoints. " +
+                    $"NextStop={Current.NextStop}, First={Current.Waypoints[0]}, " +
+                    $"Last={Current.Waypoints[^1]}, Closest={FindClosestWaypoint(Current.Waypoints, Current.NextStop)}, " +
+                    $"WaypointCount={Current.Waypoints.Count}."));
+        }
+
+        if (Current.DurationToNextStop == Current.Duration &&
+    GeoMath.EquirectangularDistance(Current.NextStop, Current.Waypoints[^1]) > NextStopMatchToleranceKm)
+        {
+            throw Log.Error(
+                0,
+                0,
+                new InvalidOperationException(
+                    $"Invalid journey: DurationToNextStop equals full Duration, but NextStop is not close to final waypoint. " +
+                    $"NextStop={Current.NextStop}, Final={Current.Waypoints[^1]}, " +
+                    $"DistanceKm={GeoMath.EquirectangularDistance(Current.NextStop, Current.Waypoints[^1]):F3}, " +
+                    $"ToleranceKm={NextStopMatchToleranceKm:F3}."));
+        }
+    }
+
+    private static void ValidateWaypoints(List<Position> waypoints)
+    {
+        if (waypoints.Count == 0)
+            throw Log.Error(0, 0, new InvalidOperationException("Journey route has no waypoints."));
+    }
+
+    private static Position FindClosestWaypoint(List<Position> waypoints, Position target)
+    {
+        ValidateWaypoints(waypoints);
+
+        return waypoints
+            .OrderBy(waypoint => GeoMath.EquirectangularDistance(waypoint, target))
+            .First();
+    }
+
+    private const double NextStopMatchToleranceKm = 0.5;
+
     /// <summary>
     /// Resolves the effective next-stop waypoint index on a route.
     /// Uses the last match because tolerance-based equality can produce multiple candidates.
@@ -316,8 +469,25 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     /// <param name="waypoints">Ordered route waypoints.</param>
     /// <param name="nextStop">Configured next-stop position.</param>
     /// <returns>Index of the best matching waypoint, or -1 if not found.</returns>
-    private static int FindNextStopIndex(List<Position> waypoints, Position nextStop) =>
-        waypoints.FindLastIndex(w => w == nextStop);
+    private static int FindNextStopIndex(List<Position> waypoints, Position nextStop)
+    {
+        var bestMatch = waypoints
+            .Select((waypoint, index) => new
+            {
+                Index = index,
+                DistanceKm = GeoMath.EquirectangularDistance(waypoint, nextStop),
+            })
+            .Where(x => x.DistanceKm <= NextStopMatchToleranceKm)
+            .OrderBy(x => x.DistanceKm)
+            .FirstOrDefault();
+
+        return bestMatch?.Index ?? throw Log.Error(
+            0,
+            0,
+            new InvalidOperationException(
+                $"Next stop not found in waypoints within tolerance. NextStop={nextStop}, " +
+                $"First={waypoints[0]}, Last={waypoints[^1]}, WaypointCount={waypoints.Count}."));
+    }
 
     /// <summary>
     /// Computes cumulative polyline length from index 0 up to <paramref name="endIndexInclusive"/>.
@@ -332,6 +502,7 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
 
         var clampedEnd = Math.Min(endIndexInclusive, waypoints.Count - 1);
         var total = 0.0;
+
         for (var i = 0; i < clampedEnd; i++)
             total += GeoMath.EquirectangularDistance(waypoints[i], waypoints[i + 1]);
 
@@ -341,6 +512,7 @@ public class Journey(Time departure, Time duration, float distanceMeters, List<P
     private void CheckTime(Time time, bool checkBeforeDeparture = true, bool checkAfterCompletion = true, bool checkAfterEtaToNextStop = true)
     {
         var completedTime = Current.Departure + Current.Duration;
+
         if (checkBeforeDeparture && time < Current.Departure)
             throw Log.Error(0, time, new ArgumentException($"Current time: {time} is before the current journey has started: {Current.Departure}."));
 

--- a/Tests/Core.test/Routing/JourneyTests.cs
+++ b/Tests/Core.test/Routing/JourneyTests.cs
@@ -398,4 +398,184 @@ public class JourneyTests
         var etaToNext = journey.Current.EtaToNextStop;
         Assert.Throws<ArgumentException>(() => journey.AdvanceTo(etaToNext + 40000));
     }
+
+    [Fact]
+    public void UpdateRoute_WhenNextStopIsSlightlyOffWaypointWithinTolerance_UsesRequestedNextStop()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+        new(3, 3),
+    };
+
+        var journey = new Journey(0, 100000, 1000, waypoints);
+
+        var nextStopWithinTolerance = new Position(2.000001, 2.000001);
+
+        journey.UpdateRoute(
+            waypoints,
+            nextStopWithinTolerance,
+            departure: 0,
+            duration: 100000,
+            newDistanceKm: 1f);
+
+        Assert.Equal(nextStopWithinTolerance, journey.Current.NextStop);
+        Assert.True(journey.Current.DurationToNextStop < journey.Current.Duration);
+        Assert.True(journey.Current.DurationToNextStop > 0);
+    }
+
+    [Fact]
+    public void UpdateRoute_WhenNextStopIsOutsideTolerance_ThrowsInvalidOperationException()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+    };
+
+        var journey = new Journey(0, 60000, 1000, waypoints);
+
+        var nextStopOutsideTolerance = new Position(2.1, 2.1);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            journey.UpdateRoute(
+                waypoints,
+                nextStopOutsideTolerance,
+                departure: 0,
+                duration: 60000,
+                newDistanceKm: 1f));
+
+        Assert.Contains("Next stop not found", ex.Message);
+    }
+
+    [Fact]
+    public void AdvanceTo_WhenExactlyAtEtaToNextStop_AllowsStoppingAtNextStop()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+        new(3, 3),
+    };
+
+        var journey = new Journey(0, 90000, 1000, waypoints);
+
+        journey.UpdateRoute(
+            waypoints,
+            nextStop: waypoints[2],
+            departure: 0,
+            duration: 90000,
+            newDistanceKm: 1f);
+
+        var etaToNextStop = journey.Current.EtaToNextStop;
+
+        var pos = journey.AdvanceTo(etaToNextStop);
+
+        Assert.Equal(waypoints[2].Latitude, pos.Latitude, precision: 3);
+        Assert.Equal(waypoints[2].Longitude, pos.Longitude, precision: 3);
+        Assert.Equal(waypoints[2], journey.Current.Waypoints[0]);
+    }
+
+    [Fact]
+    public void UpdateRoute_WhenNextStopIsFinalWaypoint_DurationToNextStopEqualsDuration()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+    };
+
+        var journey = new Journey(0, 60000, 1000, waypoints);
+
+        journey.UpdateRoute(
+            waypoints,
+            nextStop: waypoints[^1],
+            departure: 0,
+            duration: 60000,
+            newDistanceKm: 1f);
+
+        Assert.Equal(journey.Current.Duration, journey.Current.DurationToNextStop);
+        Assert.Equal(journey.Current.Eta, journey.Current.EtaToNextStop);
+    }
+
+    [Fact]
+    public void UpdateRoute_WhenNextStopIsMiddleWaypoint_DurationToNextStopIsLessThanFullDuration()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+        new(3, 3),
+    };
+
+        var journey = new Journey(0, 90000, 1000, waypoints);
+
+        journey.UpdateRoute(
+            waypoints,
+            nextStop: waypoints[1],
+            departure: 0,
+            duration: 90000,
+            newDistanceKm: 1f);
+
+        Assert.True(journey.Current.DurationToNextStop < journey.Current.Duration);
+        Assert.Equal(30u, journey.Current.DurationToNextStop.TotalSeconds, tolerance: 2);
+    }
+
+    [Fact]
+    public void UpdateRoute_WhenMultipleWaypointsAreWithinTolerance_UsesClosestWaypointForDuration()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(0, 0.001),
+        new(0, 0.004),
+        new(0, 1),
+    };
+
+        var journey = new Journey(0, 100_000_000, 100_000, waypoints);
+
+        var nextStop = new Position(0, 0.0039);
+
+        journey.UpdateRoute(
+            waypoints,
+            nextStop,
+            departure: 0,
+            duration: 100_000_000,
+            newDistanceKm: 100f);
+
+        // If it picked waypoints[1], this would be roughly 100 seconds.
+        // If it picked waypoints[2], this should be roughly 400 seconds.
+        Assert.Equal(400u, journey.Current.DurationToNextStop.TotalSeconds, tolerance: 20);
+    }
+
+    [Fact]
+    public void UpdateRoute_WhenNoWaypointIsWithinTolerance_Throws()
+    {
+        var waypoints = new List<Position>
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+    };
+
+        var journey = new Journey(0, 60000, 1000, waypoints);
+
+        var nextStopFarAway = new Position(10, 10);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            journey.UpdateRoute(
+                waypoints,
+                nextStopFarAway,
+                departure: 0,
+                duration: 60000,
+                newDistanceKm: 1f));
+
+        Assert.Contains("Next stop not found in waypoints within tolerance", ex.Message);
+    }
 }

--- a/Tests/Core.test/Routing/JourneyTests.cs
+++ b/Tests/Core.test/Routing/JourneyTests.cs
@@ -183,20 +183,25 @@ public class JourneyTests
     }
 
     [Fact]
-    public void DurationToNextStop_NotOnRoute_EqualsTotalDuration()
+    public void UpdateRoute_WhenNextStopNotOnRoute_ThrowsInvalidOperationException()
     {
         var waypoints = new List<Position>
-        {
-            new(0, 0),
-            new(1, 1),
-            new(2, 2),
-        };
+    {
+        new(0, 0),
+        new(1, 1),
+        new(2, 2),
+    };
 
         var nextStopNotOnRoute = new Position(99, 99);
         var journey = new Journey(departure: 0, duration: 60000, distanceMeters: 100, waypoints);
-        journey.UpdateRoute(waypoints, nextStopNotOnRoute, departure: 0, duration: 60000, newDistanceKm: 0.1f);
 
-        Assert.Equal(journey.Current.EtaToNextStop, journey.Current.Eta);
+        Assert.Throws<InvalidOperationException>(() =>
+            journey.UpdateRoute(
+                waypoints,
+                nextStopNotOnRoute,
+                departure: 0,
+                duration: 60000,
+                newDistanceKm: 0.1f));
     }
 
     [Fact]

--- a/Tests/Engine.test/Events/ArriveAtDestinationMetricTest.cs
+++ b/Tests/Engine.test/Events/ArriveAtDestinationMetricTest.cs
@@ -2,27 +2,42 @@ namespace Engine.test.Events;
 
 using Engine.Metrics.Events;
 using Core.Vehicles;
-using Engine.test.Builders;
 using Core.test.Builders;
 using Core.Shared;
 
 public class ArriveAtDestinationMetricTest
 {
-    /// <summary>
-    /// The Collect method should extract all required fields from the EV's journey and arrival time.
-    /// </summary>
     [Fact]
     public void Collect_ExtractsAllMetricFields()
     {
-        var departure = 100000U;
-        var originalDuration = 50000U;
-        var deviation = 12000;
+        const uint departure = 100000U;
+        const uint originalDuration = 50000U;
+        const int deviation = 12000;
         var simNow = (Time)(departure + originalDuration + deviation);
 
         var battery = CoreTestData.Battery();
         var preferences = CoreTestData.Preferences();
-        var journey = CoreTestData.Journey(waypoints: null, departure: 100000U, originalDuration: 50000U);
-        journey.UpdateRoute(new List<Position>([]), new(0, 0), departure: 100000U, duration: 62000U, newDistanceKm: 10);
+
+        var nextStop = new Position(1, 1);
+        var route = new List<Position>
+        {
+            new(0, 0),
+            nextStop,
+            new(2, 2),
+        };
+
+        var journey = CoreTestData.Journey(
+            waypoints: route,
+            departure: departure,
+            originalDuration: originalDuration);
+
+        journey.UpdateRoute(
+            route,
+            nextStop,
+            departure: departure,
+            duration: originalDuration + deviation,
+            newDistanceKm: 10);
+
         var ev = new EV(battery, preferences, journey, 150);
 
         var metric = ArrivalAtDestinationMetric.Collect(ref ev, simNow);
@@ -31,21 +46,28 @@ public class ArriveAtDestinationMetricTest
         Assert.Equal(deviation, metric.PathDeviation);
     }
 
-    /// <summary>
-    /// MissedDeadline should be true when the EV accumulated deviation that pushed
-    /// actual arrival past the expected duration.
-    /// </summary>
     [Fact]
     public void MissedDeadline_ComputedCorrectly()
     {
-        var departure = 100000U;
-        var originalDuration = 50000U;
-        var deviation = 12000U;
+        const uint departure = 100000U;
+        const uint originalDuration = 50000U;
+        const uint deviation = 12000U;
         var simNow = (Time)(departure + originalDuration + deviation);
 
         var battery = CoreTestData.Battery();
         var preferences = CoreTestData.Preferences();
-        var journey = CoreTestData.Journey(waypoints: null, departure: departure, originalDuration: originalDuration);
+
+        var route = new List<Position>
+        {
+            new(0, 0),
+            new(1, 1),
+        };
+
+        var journey = CoreTestData.Journey(
+            waypoints: route,
+            departure: departure,
+            originalDuration: originalDuration);
+
         var ev = new EV(battery, preferences, journey, 150);
 
         var metric = ArrivalAtDestinationMetric.Collect(ref ev, simNow);

--- a/Tests/Engine.test/Events/ArriveAtDestinationMetricTest.cs
+++ b/Tests/Engine.test/Events/ArriveAtDestinationMetricTest.cs
@@ -10,9 +10,9 @@ public class ArriveAtDestinationMetricTest
     [Fact]
     public void Collect_ExtractsAllMetricFields()
     {
-        const uint departure = 100000U;
-        const uint originalDuration = 50000U;
-        const int deviation = 12000;
+        var departure = 100000U;
+        var originalDuration = 50000U;
+        var deviation = 12000;
         var simNow = (Time)(departure + originalDuration + deviation);
 
         var battery = CoreTestData.Battery();
@@ -35,7 +35,7 @@ public class ArriveAtDestinationMetricTest
             route,
             nextStop,
             departure: departure,
-            duration: originalDuration + deviation,
+            duration: 62000U,
             newDistanceKm: 10);
 
         var ev = new EV(battery, preferences, journey, 150);
@@ -49,9 +49,9 @@ public class ArriveAtDestinationMetricTest
     [Fact]
     public void MissedDeadline_ComputedCorrectly()
     {
-        const uint departure = 100000U;
-        const uint originalDuration = 50000U;
-        const uint deviation = 12000U;
+        var departure = 100000U;
+        var originalDuration = 50000U;
+        var deviation = 12000U;
         var simNow = (Time)(departure + originalDuration + deviation);
 
         var battery = CoreTestData.Battery();

--- a/Tests/Engine.test/Routing/ApplyNewPathTests.cs
+++ b/Tests/Engine.test/Routing/ApplyNewPathTests.cs
@@ -2,7 +2,6 @@ namespace Engine.test.Routing;
 
 using Core.Shared;
 using Engine.Routing;
-
 using Engine.test.Builders;
 using Core.test.Builders;
 
@@ -17,9 +16,10 @@ public class ApplyNewPathToEVTests()
             originalDuration: 60000U);
 
         var stationPosition = new Position(2, 2);
-        var dummyRoute = new List<Position>([new(0, 0), stationPosition, new(5, 5)]);
-        journey.UpdateRoute(dummyRoute, stationPosition, departure: new Time(0), duration: new Time(60000), 0);
-        journey.UpdateRoute(dummyRoute, stationPosition, departure: new Time(20000), duration: new Time(40000), 0);
+        var dummyRoute = new List<Position> { new(0, 0), stationPosition, new(5, 5) };
+
+        journey.UpdateRoute(dummyRoute, stationPosition, departure: new Time(0), duration: new Time(60000), newDistanceKm: 10);
+        journey.UpdateRoute(dummyRoute, stationPosition, departure: new Time(20000), duration: new Time(40000), newDistanceKm: 10);
 
         Assert.Equal(0U, (uint)journey.Current.PathDeviation);
     }
@@ -27,21 +27,25 @@ public class ApplyNewPathToEVTests()
     [Fact]
     public void ApplyNewPathToEV_ConvertsAndRoundsDurationCorrectly()
     {
-        var ev = CoreTestData.EV(waypoints: [
-            new (0, 0),
-            new (10, 10)
-        ]);
-        var station = CoreTestData.Station(1, new(5, 5));
+        var ev = CoreTestData.EV(waypoints:
+        [
+            new(0, 0),
+        new(10, 10),
+    ]);
+
+        var station = CoreTestData.Station(1, new(10, 10));
         var fakeRouter = new FakeDestinationRouter
         {
-            ReturnedDuration = 150f, // 2.5 minutes, should round to 2
+            ReturnedDuration = 150f,
+            ReturnedPolyline = "??_qo]_qo]_qo]_qo]",
         };
+
         var applyNewPath = new EVDetourPlanner(fakeRouter);
         var currentTime = new Time(10);
 
         applyNewPath.Update(ref ev, station, currentTime);
 
-        Assert.Equal(150.0f, (uint)ev.Journey.Current.Duration);
+        Assert.Equal(150U, (uint)ev.Journey.Current.Duration);
         Assert.Equal(10U, (uint)ev.Journey.Current.Departure);
     }
 
@@ -49,18 +53,28 @@ public class ApplyNewPathToEVTests()
     public void UpdateRoute_AccumulatesPathDeviationCorrectly()
     {
         var journey = CoreTestData.Journey(
-            waypoints: null,
+            waypoints:
+            [
+                new(0, 0),
+                new(10, 10),
+            ],
             departure: new Time(100000),
             originalDuration: 50000U);
 
-        var dummyRoute = new List<Position>([]);
-        var dummyPosition = new Position(0, 0);
-        var dummyJourneyLengthkm = 10;
+        var stationPosition = new Position(5, 5);
+        var dummyRoute = new List<Position>
+        {
+            new(0, 0),
+            stationPosition,
+            new(10, 10),
+        };
 
-        journey.UpdateRoute(dummyRoute, dummyPosition, departure: new Time(100000), duration: new Time(60000), dummyJourneyLengthkm);
+        const float dummyJourneyLengthKm = 10;
+
+        journey.UpdateRoute(dummyRoute, stationPosition, departure: new Time(100000), duration: new Time(60000), dummyJourneyLengthKm);
         Assert.Equal(10000U, (uint)journey.Current.PathDeviation);
 
-        journey.UpdateRoute(dummyRoute, dummyPosition, departure: new Time(110000), duration: new Time(40000), dummyJourneyLengthkm);
+        journey.UpdateRoute(dummyRoute, stationPosition, departure: new Time(110000), duration: new Time(40000), dummyJourneyLengthKm);
         Assert.Equal(0U, (uint)journey.Current.PathDeviation);
     }
 
@@ -68,7 +82,11 @@ public class ApplyNewPathToEVTests()
     public void ApplyNewPathToEV_ThrowsArgumentException_WhenTimeIsOutOfBounds()
     {
         var ev = CoreTestData.EV(
-            waypoints: [new Position(0, 0), new Position(10, 10)],
+            waypoints:
+            [
+                new(0, 0),
+            new(10, 10),
+            ],
             departureTime: new Time(100000),
             originalDuration: 50000U);
 
@@ -79,7 +97,7 @@ public class ApplyNewPathToEVTests()
         Assert.Throws<InvalidOperationException>(() =>
             applyNewPath.Update(ref ev, station, new Time(99000)));
 
-        const uint outsideApproxTolerance = 310000; // 5 minutes and 10 seconds, which is outside the 5 minute tolerance
+        const uint outsideApproxTolerance = 310000;
 
         Assert.Throws<ArgumentException>(() =>
             applyNewPath.Update(ref ev, station, new Time(150000 + outsideApproxTolerance)));
@@ -96,6 +114,12 @@ public class ApplyNewPathToEVTests()
         public string ReturnedPolyline { get; set; } = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
 
         public RouteSegment QueryDestinationWithStop(
-            double evLon, double evLat, double stationLon, double stationLat, double destLon, double destLat, ushort index) => new(ReturnedDuration, ReturnedDistance, ReturnedPolyline);
+            double evLon,
+            double evLat,
+            double stationLon,
+            double stationLat,
+            double destLon,
+            double destLat,
+            ushort index) => new(ReturnedDuration, ReturnedDistance, ReturnedPolyline);
     }
 }

--- a/Tests/Engine.test/Routing/ApplyNewPathTests.cs
+++ b/Tests/Engine.test/Routing/ApplyNewPathTests.cs
@@ -30,8 +30,8 @@ public class ApplyNewPathToEVTests()
         var ev = CoreTestData.EV(waypoints:
         [
             new(0, 0),
-        new(10, 10),
-    ]);
+            new(10, 10),
+        ]);
 
         var station = CoreTestData.Station(1, new(10, 10));
         var fakeRouter = new FakeDestinationRouter
@@ -85,7 +85,7 @@ public class ApplyNewPathToEVTests()
             waypoints:
             [
                 new(0, 0),
-            new(10, 10),
+                new(10, 10),
             ],
             departureTime: new Time(100000),
             originalDuration: 50000U);


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->

## Description of Implementation (optional)
This PR fixes an issue where EVs could run out of battery due to incorrect route progression and next stop handling.
During a simulation i observed a case where an EV would leave its route and end up in the middle of a field as seen in this image:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/bfebb3a6-80f4-4bbc-ab68-a7b25849a47f" />
Through logging i discovered that the car that would run out of charge had its last position in this field just off the road. 
I believe the EVs NextStop did not correctly correspond to a waypoint on the route and that the previous implementation of FindNextStopIndex did not reliably select the correct waypoint. Causing an incorrect DurationToNextStop and the car continuing past the intended stop somehow ending up outside the route  

## Notes
* Some tests had to be adjusted due to rounding/precision when working with durations and distances
* I ran the simulation myself through Headless twice and both times I came to the end of the simulation. I didn't try any other seeds or configurations and maybe would be good idea for some to try on their machines and see if it also works for them. 

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
