### PR TITLE
Added a function to handle journeysampler scalars for both halfs of the day

### DIFF
--- a/Engine/Vehicles/EVFactory.cs
+++ b/Engine/Vehicles/EVFactory.cs
@@ -21,6 +21,7 @@ public class EVFactory(Random random, IJourneySamplerProvider samplersProvider, 
     private readonly AliasSampler _sampler = new([.. EVModels.Models.Select(m => m.SpawnChance)]);
     private readonly EVOptions _options = EVOptions;
     private int _nextId = 0;
+    private uint _lastJourneySamplerUpdateHour = 0;
 
     /// <summary>
     /// Creates a single EV. For batch creation use <see cref="SampleParams"/> and <see cref="Create(SampledEVParams, Time)"/>.
@@ -92,6 +93,7 @@ public class EVFactory(Random random, IJourneySamplerProvider samplersProvider, 
             throw new InvalidOperationException($"Failed to create journey for EV with source {p.SourceDest.Source} and destination {p.SourceDest.Destination}. This should not happen.");
         }
 
+        UpdateJourneySampler(departure);
         return new EV(p.Id, battery, preferences, journey, p.Config.Efficiency);
     }
 
@@ -126,6 +128,29 @@ public class EVFactory(Random random, IJourneySamplerProvider samplersProvider, 
         }
 
         return parameters;
+    }
+
+    private void UpdateJourneySampler(Time time)
+    {
+        if (time.Hours == _lastJourneySamplerUpdateHour)
+            return;
+
+        _lastJourneySamplerUpdateHour = time.Hours;
+        var (populationScalar, distanceScalar) = GetScalers(time);
+        samplersProvider.Recompute(populationScalar, distanceScalar);
+    }
+
+    private (float populationScaler, float distanceScaler) GetScalers(Time time)
+    {
+        const float baseScaler = 1f;
+        const float maxVariance = 0.6f;
+
+        var dailyFluctuation = (float)(maxVariance * Math.Sin((Math.PI * time.Hours) / 12));
+
+        var populationScaler = baseScaler + dailyFluctuation;
+        var distanceScaler = baseScaler - dailyFluctuation;
+
+        return (populationScaler, distanceScaler);
     }
 
     private Journey CreateJourney(Time departure, (Position Source, Position Destination) sourceDest)


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
Created a way for the program to change the scalers used in the JourneySampler throughout the day, so in the morning EV's drive towards big populations (Cities) and in the evening EV's drive longer.

Blue is population Scaler and Orange is distance Scaler
<img width="1800" height="396" alt="image" src="https://github.com/user-attachments/assets/0a87f003-f97c-4d5d-8198-c7c4e25f656f" />



## Notes
<!-- Anything reviewers should know: unusual decisions, limitations, or things to ignore -->

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [X] Self-review completed  
