### PR TITLE
Removed unnecessary metrics

### DIFF
--- a/Engine/Metrics/Snapshots/ChargerSnapshotMetrics.cs
+++ b/Engine/Metrics/Snapshots/ChargerSnapshotMetrics.cs
@@ -36,31 +36,14 @@ public record ChargerSnapshotMetric
     required public float Utilization { get; init; }
 
     /// <summary>
-    /// Gets the maximum power delivered by this charger during the snapshot window in kW.
-    /// </summary>
-    required public float DeliveredKW { get; init; }
-
-    /// <summary>
-    /// Gets a value indicating whether this charger is dual or single.
-    /// </summary>
-    required public bool IsDual { get; init; }
-
-    /// <summary>
-    /// Gets the remaining energy required by all cars currently at this charger to hit their Target SoC.
-    /// </summary>
-    required public float TargetEVDemandKW { get; init; }
-
-    /// <summary>
     /// Collects a snapshot from a charger at the given simulation time.
     /// </summary>
     /// <param name="charger">The charger to snapshot.</param>
     /// <param name="stationId">The id of the station that owns the charger.</param>
     /// <param name="simTime">The simulation timestamp when this snapshot is taken.</param>
     /// <param name="utilization">The charger utilization in range [0, 1].</param>
-    /// <param name="deliveredKW">The maximum power delivered by this charger during the snapshot window in kW.</param>
-    /// <param name="targetEVDemandKW">The remaining energy required by all cars currently at this charger to hit their Target SoC.</param>
     /// <returns>A snapshot metric for the specified charger at the provided simulation time.</returns>
-    public static ChargerSnapshotMetric Collect(ChargerBase charger, ushort stationId, Time simTime, float utilization, float deliveredKW, float targetEVDemandKW) =>
+    public static ChargerSnapshotMetric Collect(ChargerBase charger, ushort stationId, Time simTime, float utilization) =>
         new()
         {
             SimTime = simTime,
@@ -68,8 +51,5 @@ public record ChargerSnapshotMetric
             ChargerId = charger.Id,
             MaxKWh = charger.MaxPowerKW,
             Utilization = utilization,
-            DeliveredKW = deliveredKW,
-            IsDual = charger is DualCharger,
-            TargetEVDemandKW = targetEVDemandKW,
         };
 }

--- a/Engine/Metrics/Snapshots/StationChargerMetricsCollector.cs
+++ b/Engine/Metrics/Snapshots/StationChargerMetricsCollector.cs
@@ -44,9 +44,7 @@ public class StationMetricsCollector(List<Station> stations, StationService stat
                     charger,
                     station.Id,
                     simNow,
-                    utilizationInWindow,
-                    deliveredKWhInWindow,
-                    targetEVDemandKWh));
+                    utilizationInWindow));
 
                 totalDeliveredKWh += deliveredKWhInWindow;
                 totalMaxKWh += charger.MaxPowerKW * snapshotDurationHours;
@@ -70,8 +68,6 @@ public class StationMetricsCollector(List<Station> stations, StationService stat
             {
                 SimTime = simNow,
                 StationId = station.Id,
-                TotalDeliveredKWh = totalDeliveredKWh,
-                TotalMaxKWh = totalMaxKWh,
                 Price = station.GetPrice(simNow),
                 TotalChargers = station.Chargers.Count,
                 Reservations = reservations,

--- a/Engine/Metrics/Snapshots/StationSnapshotMetrics.cs
+++ b/Engine/Metrics/Snapshots/StationSnapshotMetrics.cs
@@ -17,16 +17,6 @@ public record StationSnapshotMetric
     required public ushort StationId { get; init; }
 
     /// <summary>
-    /// Gets the total power delivered across all chargers in kW.
-    /// </summary>
-    required public float TotalDeliveredKWh { get; init; }
-
-    /// <summary>
-    /// Gets the total maximum power capacity across all chargers in kW.
-    /// </summary>
-    required public float TotalMaxKWh { get; init; }
-
-    /// <summary>
     /// Gets the station's energy price in DKK/kWh at snapshot time.
     /// </summary>
     required public float Price { get; init; }

--- a/Tests/Engine.test/Metrics/StationServiceSnapshotTests.cs
+++ b/Tests/Engine.test/Metrics/StationServiceSnapshotTests.cs
@@ -34,12 +34,7 @@ public class StationServiceSnapshotTests
         var (chargers, stations) = collector.Collect(snapshotInterval, new Time(3600));
 
         var cs = chargers.Single();
-        var ss = stations.Single();
 
-        Assert.Equal(deliveredKwh, cs.DeliveredKW);
         Assert.Equal(expectedUtilization, cs.Utilization);
-
-        Assert.Equal(deliveredKwh, ss.TotalDeliveredKWh);
-        Assert.Equal(chargerMaxKw, ss.TotalMaxKWh);
     }
 }


### PR DESCRIPTION
# Related Issues
<!-- Use keywords like Closes/Fixes/Resolves to automatically close issues on merge -->
Closes #

## Description of Implementation (optional)
<!-- Briefly explain what this PR does and why -->
ChargerMetrics now looks like this:
<img width="653" height="90" alt="image" src="https://github.com/user-attachments/assets/ae02f3e6-643c-4830-bb82-761cb3b96ee1" />
StationMetrics now looks like this:
<img width="909" height="86" alt="image" src="https://github.com/user-attachments/assets/0c7fd371-def3-4dd4-8672-7eee05ec4d24" />

## Notes
I don't know if we also want to save the maxkwh for chargers if we are having various different power outputs now. Can remove or can keep idk if we really want to use it it might be interesting it might not

## Pre-PR Checklist
Ensure these are completed before opening the PR:

- [x] All new and modified code has been tested (explain in Notes if not tested)  
- [x] Self-review completed  
