### PR TITLE
JourneySamplerCacheToBinary

### DIFF
--- a/Engine/Init/EngineConfiguration.cs
+++ b/Engine/Init/EngineConfiguration.cs
@@ -71,7 +71,7 @@ public static class EngineConfiguration
             EVSpawnFraction = 0.1,
             ChargeBufferPercent = 0.9f,
             DistanceScaler = 1.7f,
-            GridSize = 0.025,
+            GridSize = 0.05f,
             EnergyPricesPath = new FileInfo(Path.Combine(dataPath.FullName, "energy_prices.csv")),
             OsrmPath = new FileInfo(Path.Combine(dataPath.FullName, "osrm/output.osrm")),
             CitiesPath = new FileInfo(Path.Combine(dataPath.FullName, "CityInfo.csv")),

--- a/Engine/Init/EngineConfiguration.cs
+++ b/Engine/Init/EngineConfiguration.cs
@@ -68,7 +68,7 @@ public static class EngineConfiguration
             SnapshotInterval = 1000 * 20 * 60,
             EnablePerformanceMetrics = true,
             EVDistributionWindowsSize = 30 * 60 * 1000,
-            EVSpawnFraction = 0.6,
+            EVSpawnFraction = 0.1,
             ChargeBufferPercent = 0.9f,
             DistanceScaler = 1.7f,
             GridSize = 0.025,

--- a/Engine/Init/Init.cs
+++ b/Engine/Init/Init.cs
@@ -28,10 +28,16 @@ public static class Init
     /// Initializes the Engine with the required services and configurations.
     /// </summary>
     /// <param name="services">The service collection to initialize.</param>
+    /// <param name="settings">The engine settings used to configure services.</param>
     public static void InitEngine(IServiceCollection services, EngineSettings settings)
     {
         if (settings.EnablePerformanceMetrics)
             services.AddSingleton(new PerformanceMetrics());
+
+        var polygons = InitPolygons(settings.PolygonPath);
+        var wetPolygons = InitWetPolygons(settings.WetPolygonPath);
+        var cities = InitCities(settings.CitiesPath);
+        var spawnGrid = InitSpawnGrid(polygons, wetPolygons, settings.StationsPath, settings.GridSize);
 
         services.AddSingleton(_ => new EventScheduler());
         services.AddSingleton(sp =>
@@ -85,9 +91,6 @@ public static class Init
         services.AddSingleton<IJourneySamplerProvider>(sp =>
         {
             var router = sp.GetRequiredService<IOSRMRouter>();
-            var spawnGrid = InitSpawnGrid(settings.PolygonPath, settings.WetPolygonPath, settings.StationsPath, settings.GridSize);
-            var cities = InitCities(settings.CitiesPath);
-            var wetPolygons = PolygonParser.Parse(File.ReadAllText(settings.WetPolygonPath.ToString()));
             var journeyPipeline = new JourneyPipeline(spawnGrid, cities, router);
             return new JourneySamplerProvider(journeyPipeline, (float)settings.DistanceScaler, wetPolygons);
         });
@@ -104,7 +107,6 @@ public static class Init
         services.AddSingleton(sp =>
         {
             var stations = sp.GetRequiredService<Dictionary<ushort, Station>>();
-            var spawnGrid = InitSpawnGrid(settings.PolygonPath, settings.WetPolygonPath, settings.StationsPath, settings.GridSize);
             return new SpatialGrid(spawnGrid, stations);
         });
 
@@ -217,13 +219,25 @@ public static class Init
         });
     }
 
-    private static SpawnGrid InitSpawnGrid(FileInfo polygonPath, FileInfo wetPolygonPath, FileInfo stationsPath, double size)
+    private static SpawnGrid InitSpawnGrid(
+        List<List<Position>> polygons,
+        List<List<Position>> wetPolygons,
+        FileInfo stationsPath,
+        double size)
     {
-        var polygons = PolygonParser.Parse(File.ReadAllText(polygonPath.ToString()));
-        var wetPolygons = PolygonParser.Parse(File.ReadAllText(wetPolygonPath.ToString()));
         var stations = StationParser.Parse(File.ReadAllText(stationsPath.ToString()));
 
         return Polygooner.GenerateGrid(size, polygons, wetPolygons, stations);
+    }
+
+    private static List<List<Position>> InitPolygons(FileInfo polygonPath)
+    {
+        return PolygonParser.Parse(File.ReadAllText(polygonPath.ToString()));
+    }
+
+    private static List<List<Position>> InitWetPolygons(FileInfo wetPolygonPath)
+    {
+        return PolygonParser.Parse(File.ReadAllText(wetPolygonPath.ToString()));
     }
 
     private static List<City> InitCities(FileInfo citiesPath)

--- a/Engine/Spawning/JourneySamplerCacher.cs
+++ b/Engine/Spawning/JourneySamplerCacher.cs
@@ -1,70 +1,134 @@
 namespace Engine.Spawning;
 
-using System.Text.Json;
+using System.IO;
+using Core.Shared;
 
 /// <summary>
-/// Utility class for caching journey samplers to fike. This allows us to avoid expensive recomputation of samplers during development, while still allowing for dynamic sampling based on time of day.
+/// Utility class for caching journey samplers to a fast binary format.
 /// </summary>
 internal static class JourneySamplerCache
 {
     private const string _cacheDir = "journeySamples";
+    private const string _formatSchemaVersion = "v2";
 
-    private static readonly JsonSerializerOptions _jsonOpts = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        IncludeFields = true,
-    };
-
-    /// <summary>
-    /// Ensures the directory for caching journey samplers exists.
-    /// </summary>
     public static void EnsureDirectory() => Directory.CreateDirectory(_cacheDir);
 
-    /// <summary>
-    /// Checks if a sampler for the given hour already exists.
-    /// </summary>
-    /// <param name="hour">The hour for which to check if a file already exist.</param>
-    /// <param name="distanceScaler">The distance scaler used in the sampler, used to differentiate files when the scaler is changed.</param>
-    /// <returns>Returns true if the file exist.</returns>
-    public static bool Exists(uint hour, float distanceScaler)
+    public static bool Exists(uint hour, float distanceScalar)
     {
-        var path = PathFor(hour, distanceScaler);
-        return File.Exists(path) && new FileInfo(path).Length > 10;
+        var path = PathFor(hour, distanceScalar);
+        var info = new FileInfo(path);
+        return info.Exists && info.Length > 32;
     }
 
-    /// <summary>
-    /// Writes the given sampler DTO to disk for the specified hour.
-    /// </summary>
-    /// <param name="hour">The hour for which time the sampler was computed for.</param>
-    /// <param name="journeyDTO">The sampler the should be written to file.</param>
-    /// <param name="distanceScaler">The distance scaler used in the sampler, used to differentiate files when the scaler is changed.</param>
-    public static JourneySamplerDTO Write(uint hour, JourneySamplerDTO journeyDTO, float distanceScaler)
+    public static void Write(uint hour, JourneySamplerDTO dto, float distanceScalar)
     {
-        var json = JsonSerializer.Serialize(journeyDTO, _jsonOpts);
-        if (json.Length < 10)
+        using var stream = new FileStream(PathFor(hour, distanceScalar), FileMode.Create, FileAccess.Write, FileShare.None, 4096);
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(dto.HalfLat);
+        writer.Write(dto.HalfLon);
+
+        WriteFloatArray(writer, dto.SourceWeights);
+
+        writer.Write(dto.DestinationWeights.Length);
+        foreach (var row in dto.DestinationWeights)
         {
-            throw new InvalidOperationException(
-                $"Serialised DTO for hour {hour} is empty: {json}");
+            WriteFloatArray(writer, row);
         }
 
-        File.WriteAllText(PathFor(hour, distanceScaler), json);
-        return journeyDTO;
+        WritePositions(writer, dto.CellCenters);
+        WritePositions(writer, dto.CityCenters);
+
+        writer.Write(dto.WetPolygons.Count);
+        foreach (var poly in dto.WetPolygons)
+        {
+            WritePositions(writer, poly);
+        }
     }
 
-    /// <summary>
-    /// Reads the sampler from the specified hour.
-    /// </summary>
-    /// <param name="hour">The hour for which sampler is needed.</param>
-    /// <param name="distanceScaler">The distance scaler used in the sampler, used to differentiate files when the scaler is changed.</param>
-    /// <returns>Returns a JourneySamplerDTO.</returns>
-    public static JourneySamplerDTO Read(uint hour, float distanceScaler)
+    public static JourneySamplerDTO Read(uint hour, float distanceScalar)
     {
-        var json = File.ReadAllText(PathFor(hour, distanceScaler));
-        return JsonSerializer.Deserialize<JourneySamplerDTO>(json, _jsonOpts)
-            ?? throw new InvalidOperationException(
-                $"Failed to deserialize sampler for hour {hour}.");
+        using var stream = new FileStream(PathFor(hour, distanceScalar), FileMode.Open, FileAccess.Read, FileShare.Read, 4096);
+        using var reader = new BinaryReader(stream);
+
+        var halfLat = reader.ReadDouble();
+        var halfLon = reader.ReadDouble();
+
+        var sourceWeights = ReadFloatArray(reader);
+
+        var destLen = reader.ReadInt32();
+        var destinationWeights = new float[destLen][];
+        for (var i = 0; i < destLen; i++)
+        {
+            destinationWeights[i] = ReadFloatArray(reader);
+        }
+
+        var cellCenters = ReadPositionsArray(reader);
+        var cityCenters = ReadPositionsArray(reader);
+
+        var polyCount = reader.ReadInt32();
+        var wetPolygons = new List<List<Position>>(polyCount);
+        for (var i = 0; i < polyCount; i++)
+        {
+            wetPolygons.Add(ReadPositionsList(reader));
+        }
+
+        return new JourneySamplerDTO(
+            sourceWeights,
+            destinationWeights,
+            cellCenters,
+            cityCenters,
+            halfLat,
+            halfLon,
+            wetPolygons);
     }
 
-    private static string PathFor(uint hour, float distanceScaler) =>
-        Path.Combine(_cacheDir, $"sampler_{hour}_{distanceScaler}.json");
+    private static void WriteFloatArray(BinaryWriter writer, float[] array)
+    {
+        writer.Write(array.Length);
+        foreach (var val in array) writer.Write(val);
+    }
+
+    private static float[] ReadFloatArray(BinaryReader reader)
+    {
+        var len = reader.ReadInt32();
+        var array = new float[len];
+        for (var i = 0; i < len; i++) array[i] = reader.ReadSingle();
+        return array;
+    }
+
+    private static void WritePositions(BinaryWriter writer, IReadOnlyCollection<Position> positions)
+    {
+        writer.Write(positions.Count);
+        foreach (var pos in positions)
+        {
+            writer.Write(pos.Longitude);
+            writer.Write(pos.Latitude);
+        }
+    }
+
+    private static Position[] ReadPositionsArray(BinaryReader reader)
+    {
+        var len = reader.ReadInt32();
+        var array = new Position[len];
+        for (var i = 0; i < len; i++)
+        {
+            array[i] = new Position(reader.ReadDouble(), reader.ReadDouble());
+        }
+        return array;
+    }
+
+    private static List<Position> ReadPositionsList(BinaryReader reader)
+    {
+        var len = reader.ReadInt32();
+        var list = new List<Position>(len);
+        for (var i = 0; i < len; i++)
+        {
+            list.Add(new Position(reader.ReadDouble(), reader.ReadDouble()));
+        }
+        return list;
+    }
+
+    private static string PathFor(uint hour, float distanceScalar) =>
+        Path.Combine(_cacheDir, $"sampler_{_formatSchemaVersion}_{hour}_{distanceScalar}.bin");
 }

--- a/Engine/Spawning/JourneySamplerCacher.cs
+++ b/Engine/Spawning/JourneySamplerCacher.cs
@@ -38,7 +38,7 @@ internal static class JourneySamplerCache
     /// <param name="hour">The hour for which time the sampler was computed for.</param>
     /// <param name="journeyDTO">The sampler the should be written to file.</param>
     /// <param name="distanceScaler">The distance scaler used in the sampler, used to differentiate files when the scaler is changed.</param>
-    public static void Write(uint hour, JourneySamplerDTO journeyDTO, float distanceScaler)
+    public static JourneySamplerDTO Write(uint hour, JourneySamplerDTO journeyDTO, float distanceScaler)
     {
         var json = JsonSerializer.Serialize(journeyDTO, _jsonOpts);
         if (json.Length < 10)
@@ -48,6 +48,7 @@ internal static class JourneySamplerCache
         }
 
         File.WriteAllText(PathFor(hour, distanceScaler), json);
+        return journeyDTO;
     }
 
     /// <summary>

--- a/Engine/Spawning/JourneySamplerProvider.cs
+++ b/Engine/Spawning/JourneySamplerProvider.cs
@@ -56,8 +56,8 @@ public sealed class JourneySamplerProvider : IJourneySamplerProvider
 
         var popScalar = GetScalers(hour);
         var journeyDTO = _pipeline.ComputeDTO(popScalar, _distanceScalar, _wetPolygons);
-        var sampler = JourneySamplerCache.Write(hour, journeyDTO, _distanceScalar);
-        return JourneyPipeline.FromDTO(sampler);
+        JourneySamplerCache.Write(hour, journeyDTO, _distanceScalar);
+        return JourneyPipeline.FromDTO(journeyDTO);
     }
 
     private JourneySamplers LoadHourFromDisk(uint hour)
@@ -66,15 +66,13 @@ public sealed class JourneySamplerProvider : IJourneySamplerProvider
         return JourneyPipeline.FromDTO(journeyDTO);
     }
 
-    private float GetScalers(Time time)
+    private float GetScalers(uint hour)
     {
         const float baseScaler = 0.8f;
         const float maxVariance = 0.7f;
 
-        var dailyFluctuation = (float)(maxVariance * Math.Sin((Math.PI * time.Hours) / 12));
+        var dailyFluctuation = (float)(maxVariance * Math.Sin((Math.PI * hour) / 12));
 
-        var populationScaler = baseScaler + dailyFluctuation;
-
-        return populationScaler;
+        return baseScaler + dailyFluctuation;
     }
 }

--- a/Engine/Spawning/JourneySamplerProvider.cs
+++ b/Engine/Spawning/JourneySamplerProvider.cs
@@ -32,10 +32,7 @@ public sealed class JourneySamplerProvider : IJourneySamplerProvider
 
         JourneySamplerCache.EnsureDirectory();
 
-        Parallel.For(0, 24, hour => EnsureSamplerOnDisk((uint)hour));
-
-        // Keep hourly samplers in memory so SetCurrent avoids disk IO and JSON deserialization.
-        Parallel.For(0, 24, hour => _hourlySamplers[hour] = LoadHourFromDisk((uint)hour));
+        Parallel.For(0, 24, hour => _hourlySamplers[hour] = EnsureSamplerOnDisk((uint)hour));
 
         Current = _hourlySamplers[0];
     }
@@ -53,13 +50,14 @@ public sealed class JourneySamplerProvider : IJourneySamplerProvider
         }
     }
 
-    private void EnsureSamplerOnDisk(uint hour)
+    private JourneySamplers EnsureSamplerOnDisk(uint hour)
     {
-        if (JourneySamplerCache.Exists(hour, _distanceScalar)) return;
+        if (JourneySamplerCache.Exists(hour, _distanceScalar)) return LoadHourFromDisk(hour);
 
         var popScalar = GetScalers(hour);
         var journeyDTO = _pipeline.ComputeDTO(popScalar, _distanceScalar, _wetPolygons);
-        JourneySamplerCache.Write(hour, journeyDTO, _distanceScalar);
+        var sampler = JourneySamplerCache.Write(hour, journeyDTO, _distanceScalar);
+        return JourneyPipeline.FromDTO(sampler);
     }
 
     private JourneySamplers LoadHourFromDisk(uint hour)


### PR DESCRIPTION
- **Changed to binary**
- **Made gridsize double size, halfed startup time**

Changed the JourneySampler to be saved as a binary file instead of JSON, which took the compile time on my pc from 47 sec to 28 sec on the API.

From that doubled the grid size from 0.025 to 0.05 which made the startup time go down to 16 sec

Also changed Init to not load InitSpawnGrid multiple times, while also normalising the other Init functions to do the same